### PR TITLE
Prevent use of bamrecord if HTS not present

### DIFF
--- a/Sequence/samfunctions.hpp
+++ b/Sequence/samfunctions.hpp
@@ -7,14 +7,17 @@
 namespace Sequence
 {
   unsigned alignment_length( const samrecord & b );
-  unsigned alignment_length( const bamrecord & b );
   unsigned insertion_distance( const samrecord & b );
-  unsigned insertion_distance( const bamrecord & b );
   unsigned deletion_distance( const samrecord & b );
-  unsigned deletion_distance( const bamrecord & b );
   unsigned ngaps( const samrecord & b );
-  unsigned ngaps( const bamrecord & b );
   unsigned mismatches( const samrecord & b );
+
+#ifdef HAVE_HTSLIB
+  unsigned alignment_length( const bamrecord & b );
+  unsigned insertion_distance( const bamrecord & b );
+  unsigned deletion_distance( const bamrecord & b );
+  unsigned ngaps( const bamrecord & b );
   unsigned mismatches( const bamrecord & b );
+#endif
 }
 #endif

--- a/src/hts/samfunctions.cc
+++ b/src/hts/samfunctions.cc
@@ -55,6 +55,7 @@ namespace Sequence
     return sum;
   }
 
+#ifdef HAVE_HTSLIB
   unsigned alignment_length(const bamrecord & b)
   /*!
     \param b A Sequence::bamrecord
@@ -84,6 +85,7 @@ namespace Sequence
 		  });
     return sum;
   }
+#endif
 
   unsigned insertion_distance( const samrecord & b )
   /*!
@@ -103,6 +105,7 @@ namespace Sequence
     return sum;
   }
 
+#ifdef HAVE_HTSLIB
   unsigned insertion_distance( const bamrecord & b )
   /*!
     \param b A Sequence::bamrecord
@@ -118,6 +121,7 @@ namespace Sequence
 		    }});
     return sum;
   }
+#endif
 
   unsigned deletion_distance( const samrecord & b )
   /*!
@@ -137,6 +141,7 @@ namespace Sequence
     return sum;
   }
 
+#ifdef HAVE_HTSLIB
   unsigned deletion_distance( const bamrecord & b )
   /*!
     \param b A Sequence::bamrecord
@@ -153,6 +158,7 @@ namespace Sequence
 	     });
     return sum;
   }
+#endif
 
   unsigned ngaps( const samrecord & b )
   /*!
@@ -163,6 +169,7 @@ namespace Sequence
     return ( deletion_distance(b) + insertion_distance(b) );
   }
 
+#ifdef HAVE_HTSLIB
   unsigned ngaps( const bamrecord & b )
   /*!
     \param b A Sequence::bamrecord
@@ -171,6 +178,7 @@ namespace Sequence
   {
     return ( deletion_distance(b) + insertion_distance(b) );
   }
+#endif
 
   unsigned mismatches( const samrecord & b )
   /*!
@@ -206,6 +214,7 @@ namespace Sequence
     return sum - ng;
   }
 
+#ifdef HAVE_HTSLIB
   unsigned mismatches( const bamrecord & b )
   /*!
     \param b A Sequence::bamrecord
@@ -231,4 +240,5 @@ namespace Sequence
     if( ng > sum ) return numeric_limits<unsigned>::max();
     return sum - ng;
   }
+#endif
 }


### PR DESCRIPTION
Several functions consuming bamrecords were not guarded by the feature
detection macro HAVE_HTSLIB that Sequence::bamrecord's definition was
guarded with.
