### PR TITLE
Use lambda instead of bind of unresolved overload

### DIFF
--- a/src/SummStats/PolySNP.cc
+++ b/src/SummStats/PolySNP.cc
@@ -800,18 +800,18 @@ namespace Sequence
 		  {
 		    _count += std::count_if(rep->_data->begin(),
 					    rep->_data->begin()+rep->_outgroup,
-					    std::bind(notDifferent<string>,
+					    std::bind(&notDifferent<string>,
 						      std::placeholders::_1,*beg,false,true));
 		    _count += std::count_if(rep->_data->begin()+rep->_outgroup+1,
 					    rep->_data->end(),
-					    std::bind(notDifferent<string>,
+					    std::bind(&notDifferent<string>,
 						      std::placeholders::_1,*beg,false,true));
 		  }
 		else
 		  {
 		    _count += std::count_if(rep->_data->begin(),
 					    rep->_data->end(),
-					    std::bind(notDifferent<string>,
+					    std::bind(&notDifferent<string>,
 						      std::placeholders::_1,*beg,false,true));
 		  }
 		rep->_DVH -= pow (double (_count) / rep->_totsam, 2.0);


### PR DESCRIPTION
The standard library bind(f,...) requires a sufficiently resolved
callable type, the overloads of notDifferent with default parameters
prevents selection of the intended overload.
