### PR TITLE
Avoid putting std::isfinite in global namespace

### DIFF
--- a/src/Coalescent/CoalescentCoalesce.cc
+++ b/src/Coalescent/CoalescentCoalesce.cc
@@ -21,6 +21,8 @@ long with libsequence.  If not, see <http://www.gnu.org/licenses/>.
 
 */
 
+#include <stdlib.h>
+
 #include <Sequence/Coalescent/Coalesce.hpp>
 namespace Sequence
 {

--- a/src/Comeron95.cc
+++ b/src/Comeron95.cc
@@ -42,7 +42,6 @@ long with libsequence.  If not, see <http://www.gnu.org/licenses/>.
 
 using std::log;
 using std::toupper;
-using std::isfinite;
 /*!
   \defgroup kaks Classes related to the calculation of Ka and Ks
   \ingroup divergence
@@ -50,6 +49,7 @@ using std::isfinite;
 
 namespace Sequence
   {
+  using std::isfinite;
   Comeron95::Comeron95 (const Sequence::Seq * seqa,
                         const Sequence::Seq * seqb, 
 			int max, 

--- a/src/Kimura80.cc
+++ b/src/Kimura80.cc
@@ -37,10 +37,10 @@ long with libsequence.  If not, see <http://www.gnu.org/licenses/>.
 
 //using std::isnan;
 using std::log;
-using std::isfinite;
 
 namespace Sequence
   {
+  using std::isfinite;
   Kimura80::Kimura80 (const Sequence::Seq * seqa, const Sequence::Seq * seqb):
     seqlen (seqa->length())
       /*!

--- a/src/SummStats/HKA.cc
+++ b/src/SummStats/HKA.cc
@@ -24,8 +24,6 @@ long with libsequence.  If not, see <http://www.gnu.org/licenses/>.
 #include <Sequence/HKA.hpp>
 #include <cmath>
 
-using std::isfinite;
-
 namespace 
 {
   double Cn(unsigned n)
@@ -51,6 +49,7 @@ namespace
 
 namespace Sequence
 {
+  using std::isfinite;
   HKAdata::HKAdata() : SA(0),SB(0),D(0),nA(0),nB(0)
 		  /*!
 		    default constructor


### PR DESCRIPTION
Some compilers/stdlibs (Intel 15 / libstdc++ 4.6) have different
isfinite functions in the global namespace and in namespace std.

Using using statements to put std::isfinite in the global namespace
or an global unnamed namespace makes unqualified isfinite(x) calls
ambiguous.

Dealing with cmath vs. math.h and where they put their definitions is a
proper mess, putting the alias in the closest namespace yields the right
result on both GCC 4.9.1 and Intel 15.

Also, stdlib.h needed for malloc/free.
