### PR TITLE
added first new bits of VariantMatrix code

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -319,7 +319,6 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
-runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/Sequence/Coalescent/Makefile.in
+++ b/Sequence/Coalescent/Makefile.in
@@ -326,7 +326,6 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
-runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/Sequence/Coalescent/bits/Makefile.in
+++ b/Sequence/Coalescent/bits/Makefile.in
@@ -284,7 +284,6 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
-runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/Sequence/Makefile.am
+++ b/Sequence/Makefile.am
@@ -65,4 +65,6 @@ pkginclude_HEADERS = AlignStream.hpp\
 	bamrecord.hpp \
 	bamreader.hpp \
 	SeqAlphabets.hpp \
-	threading.hpp
+	threading.hpp \
+	VariantMatrix.hpp \
+	VariantMatrixViews.hpp

--- a/Sequence/Makefile.in
+++ b/Sequence/Makefile.in
@@ -326,7 +326,6 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
-runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
@@ -399,7 +398,9 @@ pkginclude_HEADERS = AlignStream.hpp\
 	bamrecord.hpp \
 	bamreader.hpp \
 	SeqAlphabets.hpp \
-	threading.hpp
+	threading.hpp \
+	VariantMatrix.hpp \
+	VariantMatrixViews.hpp
 
 all: all-recursive
 

--- a/Sequence/SummStats/Makefile.in
+++ b/Sequence/SummStats/Makefile.in
@@ -284,7 +284,6 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
-runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/Sequence/VariantMatrix.hpp
+++ b/Sequence/VariantMatrix.hpp
@@ -1,0 +1,88 @@
+#ifndef SEQUENCE_VARIANT_MATRIX_HPP__
+#define SEQUENCE_VARIANT_MATRIX_HPP__
+
+#include <cstdint>
+#include <cstddef>
+#include <utility>
+#include <vector>
+#include <limits>
+#include <stdexcept>
+#include <type_traits>
+
+static_assert(sizeof(std::int8_t) == sizeof(char),
+              "sizeof(char) is not 8 bits");
+
+namespace Sequence
+{
+    struct VariantMatrix
+    /// Matrix representation of variation data.
+    /// The data structure is a row-major matrix.
+    /// Variants are represented by 8-bit integers.
+    /// Negative values represent missing data,
+    /// thus allowing up to 128 non-missing states
+    /// per variable site.
+    ///
+    /// Rows are sites, columns are either haplotypes
+    /// or are populated as necessary in the case of
+    /// genotype (unphased) data.  Storing variable
+    /// sites in rows places the performance priority
+    /// on sites over haplotypes.
+    ///
+    /// The only reserved character state is
+    /// std::numeric_limits<std::int8_t>::min(),
+    /// which is used to represent masked data.
+    /// That reserved value is VariantMatrix::mask,
+    /// which is a static constant.
+    ///
+    /// \version 1.9.2
+    {
+        /// Data stored in matrix form with rows as sites.
+        std::vector<std::int8_t> data;
+        /// Position of sites.
+        std::vector<double> positions;
+        /// Number of sites in data set.
+        std::size_t nsites;
+        /// Sample size of data set.
+        std::size_t nsam;
+        /// Reserved value for masked data
+        static const std::int8_t mask;
+
+        template <typename data_input, typename positions_input>
+        VariantMatrix(data_input&& data_, positions_input&& positions_)
+            /// \brief "Perfect-forwarding" constructor.
+            ///
+            /// std::invalid_argument will be thrown if
+            /// data.size() % positions.size() != 0.0.
+            : data(std::forward<data_input>(data_)),
+              positions(std::forward<positions_input>(positions_)),
+              nsites(positions.size()),
+              nsam(data.size() / positions.size())
+        {
+            if (data.size() % positions.size() != 0.0)
+                {
+                    throw std::invalid_argument("incorrect dimensions");
+                }
+        }
+
+        // Non range-checked access
+
+        /// \brief Get data from marker `site` and haplotype `haplotype`.
+        /// No range-checking is done.
+        std::int8_t& get(const std::size_t site, const std::size_t haplotype);
+        /// \brief Get data from marker `site` and haplotype `haplotype`.
+        /// No range-checking is done.
+        const std::int8_t& get(const std::size_t site,
+                               const std::size_t haplotype) const;
+
+        // Ranged-checked access after std::vector<T>::at.
+        /// \brief Get data from marker `site` and haplotype `haplotype`.
+        /// std::out_of_range is thrown if indexes are invalid.
+        std::int8_t& at(const std::size_t site, const std::size_t haplotype);
+        /// \brief Get data from marker `site` and haplotype `haplotype`.
+        /// std::out_of_range is thrown if indexes are invalid.
+        const std::int8_t& at(const std::size_t site,
+                              const std::size_t haplotype) const;
+    };
+}
+
+#endif

--- a/Sequence/VariantMatrixViews.hpp
+++ b/Sequence/VariantMatrixViews.hpp
@@ -1,0 +1,58 @@
+#ifndef SEQUENCE_VARIANT_MATRIX_VIEWS_HPP__
+#define SEQUENCE_VARIANT_MATRIX_VIEWS_HPP__
+
+#include "VariantMatrix.hpp"
+#include "bits/variant_matrix_views_internal.hpp"
+
+namespace Sequence
+/// The name space
+{
+    /// View of a VariantMatrix row (a variable site)
+    using RowView = internal::row_view_<std::int8_t*>;
+    /// Const view of a VariantMatrix row (a variable site)
+    using ConstRowView = internal::row_view_<const std::int8_t*>;
+    /// View of a VariantMatrix column ("haplotype")
+    using ColView = internal::col_view_<std::int8_t*>;
+    /// Const view of a VariantMatrix column ("haplotype")
+    using ConstColView = internal::col_view_<const std::int8_t*>;
+
+    // Rather than have member functions, we will have standalone functions:
+
+    // The following could (should?) be declared noexcept(false):
+
+    /// \brief Return a ConstRowView from VariantMatrix `m` at row `row`.
+    /// std::out_of_range is thrown if `row` is out of range.
+    ConstRowView get_RowView(const VariantMatrix& m, const std::size_t row);
+
+    /// Return a RowView from VariantMatrix `m` at row `row`.
+    /// std::out_of_range is thrown if `row` is out of range.
+    RowView get_RowView(VariantMatrix& m, const std::size_t row);
+
+    /// \brief Return a ConstRowView from VariantMatrix `m` at row `row`.
+    /// std::out_of_range is thrown if `row` is out of range.
+    ConstRowView get_ConstRowView(const VariantMatrix& m,
+                                  const std::size_t row);
+
+    /// \brief Return a ConstRowView from VariantMatrix `m` at row `row`.
+    /// std::out_of_range is thrown if `row` is out of range.
+    ConstRowView get_ConstRowView(VariantMatrix& m, const std::size_t row);
+
+    /// \brief Return a ColView from VariantMatrix `m` at col `col`.
+    /// std::out_of_range is thcoln if `col` is out of range.
+    ColView get_ColView(VariantMatrix& m, const std::size_t col);
+
+    /// \brief Return a ConstColView from VariantMatrix `m` at col `col`.
+    /// std::out_of_range is thcoln if `col` is out of range.
+    ConstColView get_ColView(const VariantMatrix& m, const std::size_t col);
+
+    /// \brief Return a ConstColView from VariantMatrix `m` at col `col`.
+    /// std::out_of_range is thcoln if `col` is out of range.
+    ConstColView get_ConstColView(VariantMatrix& m, const std::size_t col);
+    
+    /// \brief Return a ConstColView from VariantMatrix `m` at col `col`.
+    /// std::out_of_range is thcoln if `col` is out of range.
+    ConstColView get_ConstColView(const VariantMatrix& m,
+                                  const std::size_t col);
+}
+
+#endif

--- a/Sequence/bits/Makefile.am
+++ b/Sequence/bits/Makefile.am
@@ -11,4 +11,5 @@ pkginclude_HEADERS = PolySites.tcc\
 		Correlations.tcc\
 		descriptiveStats.tcc\
 		PolyTableFunctions.tcc\
-		Snn.tcc
+		Snn.tcc \
+		variant_matrix_views_internal.hpp

--- a/Sequence/bits/Makefile.in
+++ b/Sequence/bits/Makefile.in
@@ -284,7 +284,6 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
-runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
@@ -304,7 +303,8 @@ pkginclude_HEADERS = PolySites.tcc\
 		Correlations.tcc\
 		descriptiveStats.tcc\
 		PolyTableFunctions.tcc\
-		Snn.tcc
+		Snn.tcc \
+		variant_matrix_views_internal.hpp
 
 all: all-am
 

--- a/Sequence/bits/variant_matrix_views_internal.hpp
+++ b/Sequence/bits/variant_matrix_views_internal.hpp
@@ -1,0 +1,437 @@
+#ifndef SEQUENCE_VARIANT_MATRIX_INTERNAL_HPP__
+#define SEQUENCE_VARIANT_MATRIX_INTERNAL_HPP__
+
+#include <iterator>
+#include <cstdint>
+#include <cstddef>
+#include <stdexcept>
+#include <vector>
+#include <type_traits>
+
+namespace Sequence
+{
+    namespace internal
+    {
+        template <typename T> struct row_view_
+        /// Implementation details for Sequence::RowView and
+        /// Sequence::ConstRowView
+        {
+            static_assert(std::is_pointer<T>::value, "T must be pointer type");
+            /// Pointer to row data
+            T data;
+            /// Data type
+            using dtype = typename std::remove_pointer<T>::type;
+            /// Number of elements in row.
+            std::size_t row_size;
+
+            row_view_(T data_, std::size_t row_size_)
+            /// Constructor
+                : data(data_), row_size(row_size_)
+            {
+            }
+            inline dtype& operator[](const std::size_t i)
+            /// Element access without range checking
+            {
+                return data[i];
+            }
+            inline const dtype& operator[](const std::size_t i) const
+            /// Element access without range checking
+            {
+                return data[i];
+            }
+            inline dtype&
+            at(const std::size_t i)
+            /// Range-checked access
+            {
+                if (i >= row_size)
+                    {
+                        throw std::out_of_range("index out of range");
+                    }
+                return data[i];
+            }
+            inline const dtype&
+            at(const std::size_t i) const
+            /// Range-checked access
+            {
+                if (i >= row_size)
+                    {
+                        throw std::out_of_range("index out of range");
+                    }
+                return data[i];
+            }
+            std::size_t
+            size() const
+            /// Number of elements
+            {
+                return row_size;
+            }
+
+            using iterator = dtype*;
+            using const_iterator = const dtype*;
+            using reverse_iterator = std::reverse_iterator<iterator>;
+            using const_reverse_iterator
+                = std::reverse_iterator<const_iterator>;
+
+            iterator
+            begin()
+            /// Get iterator to start of range
+            {
+                return data;
+            }
+            iterator
+            end()
+            /// Get iterator to end of range
+            {
+                return data + row_size;
+            }
+            const_iterator
+            begin() const
+            /// Get const iterator to start of range
+            {
+                return data;
+            }
+            const_iterator
+            end() const
+            /// Get const iterator to end of range
+            {
+                return data + row_size;
+            }
+            const_iterator
+            cbegin() const
+            /// Get const iterator to start of range
+            {
+                return this->begin();
+            }
+            const_iterator
+            cend() const
+            /// Get const iterator to end of range
+            {
+                return this->end();
+            }
+
+            // Reverse iterators
+            reverse_iterator
+            rbegin()
+            /// Reverse iterator.  Points to start of reversed range.
+            {
+                return reverse_iterator(data + row_size);
+            }
+            reverse_iterator
+            rend()
+            /// Reverse iterator.  Points to end of reversed range.
+            {
+                return reverse_iterator(data);
+            }
+            const_reverse_iterator
+            rbegin() const
+            /// Const reverse iterator.  Points to start of reversed range.
+            {
+                return reverse_iterator(data + row_size);
+            }
+            const_reverse_iterator
+            rend() const
+            /// Const reverse iterator.  Points to end of reversed range.
+            {
+                return reverse_iterator(data);
+            }
+            const_reverse_iterator
+            crbegin() const
+            /// Const reverse iterator.  Points to start of reversed range.
+            {
+                return this->rbegin();
+            }
+            const_reverse_iterator
+            crend() const
+            /// Const reverse iterator.  Points to end of reversed range.
+            {
+                return this->rend();
+            }
+
+            std::vector<std::int8_t>
+            copy() const
+            /// Return copy of the view as std::vector<std::int8_t>
+            {
+                return std::vector<std::int8_t>(this->cbegin(), this->cend());
+            }
+
+            friend void
+            swap(row_view_& a, row_view_& b)
+            /// Allow swap via argument-dependent lookup, or "ADL"
+            {
+                auto bi = b.begin();
+                for (auto ai = a.begin(); ai != a.end(); ++ai, ++bi)
+                    {
+                        std::swap(*ai, *bi);
+                    }
+            }
+        };
+
+        template <typename T> struct col_view_
+        /// Implementation details for Sequence::ColView and
+        /// Sequence::ConstColView
+        {
+            static_assert(std::is_pointer<T>::value, "T must be pointer type");
+            /// Pointer to column data
+            T data;
+            /// data type
+            using dtype = typename std::remove_pointer<T>::type;
+
+            /// data + col_end marks the end of the column data
+            std::size_t col_end;
+            /// Stride of the data in the column
+            std::size_t stride;
+
+            col_view_(T data_, std::size_t col_end_, std::size_t stride_)
+            /// Constructor
+                : data(data_), col_end(col_end_), stride(stride_)
+            {
+            }
+            inline dtype& operator[](const std::size_t i)
+            /// Element access without range checking.
+            {
+                return data[i * stride];
+            }
+            inline const dtype& operator[](const std::size_t i) const
+            /// Element access without range checking.
+            {
+                return data[i * stride];
+            }
+            inline dtype&
+            at(const std::size_t i)
+            /// Range-checked access
+            {
+                if (i >= col_end / stride)
+                    {
+                        throw std::out_of_range("index out of range");
+                    }
+                return data[i * stride];
+            }
+            inline const dtype&
+            at(const std::size_t i) const
+            /// Range-checked access
+            {
+                if (i >= col_end / stride)
+                    {
+                        throw std::out_of_range("index out of range");
+                    }
+                return data[i * stride];
+            }
+            std::size_t
+            size() const
+            /// Number of elements
+            {
+                return col_end / stride;
+            }
+
+            template <typename POINTER> struct iterator_
+            /// Iterator for column views.
+            /// This is a C++11 standard compliant iterator.
+            {
+                static_assert(std::is_pointer<POINTER>::value,
+                              "iterator must wrap a pointer type");
+                /// Difference type
+                using difference_type =
+                    typename std::iterator_traits<POINTER>::difference_type;
+                /// Value type
+                using value_type =
+                    typename std::iterator_traits<POINTER>::value_type;
+                /// Reference type
+                using reference =
+                    typename std::iterator_traits<POINTER>::reference;
+                /// Pointer type
+                using pointer = POINTER;
+                /// Iterator category
+                using iterator_category =
+                    typename std::iterator_traits<POINTER>::iterator_category;
+
+                /// Iterator data
+                mutable POINTER data;
+
+                /// Stride needed to increment/decrement
+                difference_type stride;
+                /// Offset w.r.to data
+                difference_type offset;
+                explicit iterator_(POINTER data_, difference_type stride_,
+                                   difference_type offset_)
+                    : data{ data_ }, stride{ stride_ }, offset{ offset_ }
+                /// Constructor
+                {
+                }
+
+                /// Get value pointed to
+                reference operator*() { return *(data + offset); }
+
+                /// Get value pointed to
+                const reference operator*() const { return *(data + offset); }
+
+                iterator_&
+                operator=(const iterator_& rhs)
+                /// Assignment operator
+                {
+                    this->data = rhs.data;
+                    this->stride = rhs.stride;
+                    this->offset = rhs.offset;
+                }
+                iterator_&
+                operator+(difference_type d)
+                {
+                    offset += d * stride;
+                    return *this;
+                }
+                iterator_& operator++() { return *this + 1; }
+                iterator_&
+                operator+=(difference_type d)
+                {
+                    return *this + d;
+                }
+
+                iterator_&
+                operator-(difference_type d)
+                {
+                    return *this + -d;
+                }
+                iterator_& operator--() { return *this - 1; }
+                iterator_&
+                operator-=(difference_type d)
+                {
+                    return *this - d;
+                }
+                bool
+                operator<=(const iterator_ rhs) const
+                {
+                    return (this->data + this->offset)
+                           <= (rhs.data + rhs.offset);
+                }
+                bool
+                operator<(const iterator_ rhs) const
+                {
+                    return (this->data + this->offset)
+                           < (rhs.data + rhs.offset);
+                }
+                bool
+                operator>(const iterator_ rhs) const
+                {
+                    return !(*this <= rhs);
+                }
+                bool
+                operator>=(const iterator_ rhs) const
+                {
+                    return !(*this < rhs);
+                }
+                bool
+                operator==(const iterator_ rhs) const
+                {
+                    return !(*this < rhs) && !(*this > rhs);
+                }
+                bool
+                operator!=(const iterator_ rhs) const
+                {
+                    return !(*this == rhs);
+                }
+            };
+
+            using iterator = iterator_<dtype*>;
+            using const_iterator = iterator_<const dtype*>;
+            using reverse_iterator = std::reverse_iterator<iterator>;
+            using const_reverse_iterator
+                = std::reverse_iterator<const_iterator>;
+
+            iterator
+            begin()
+            /// Get iterator to start of range
+            {
+                return iterator(data, stride, 0);
+            }
+            iterator
+            end()
+            /// Get iterator to end of range
+            {
+                return iterator(data, stride, col_end);
+            }
+            const_iterator
+            begin() const
+            /// Get const iterator to end of range
+            {
+                return const_iterator(data, stride, 0);
+            }
+            const_iterator
+            end() const
+            /// Get const iterator to end of range
+            {
+                return const_iterator(data, stride, col_end);
+            }
+            const_iterator
+            cbegin() const
+            /// Get const iterator to start of range
+            {
+                return this->begin();
+            }
+            const_iterator
+            cend() const
+            /// Get const iterator to end of range
+            {
+                return this->end();
+            }
+
+            // Reverse iterators
+            reverse_iterator
+            rbegin()
+            /// Reverse iterator.  Points to start of reversed range.
+            {
+                return reverse_iterator(iterator(data, stride, col_end));
+            }
+            reverse_iterator
+            rend()
+            /// Reverse iterator.  Points to end of reversed range.
+            {
+                return reverse_iterator(iterator(data, stride, 0));
+            }
+
+            const_reverse_iterator
+            rbegin() const
+            /// Const reverse iterator.  Points to end of reversed range.
+            {
+                return const_reverse_iterator(
+                    const_iterator(data, stride, col_end));
+            }
+            const_reverse_iterator
+            rend() const
+            /// Const reverse iterator.  Points to end of reversed range.
+            {
+                return const_reverse_iterator(const_terator(data, stride, 0));
+            }
+            const_reverse_iterator
+            crbegin() const
+            /// Const reverse iterator.  Points to start of reversed range.
+            {
+                return this->rbegin();
+            }
+            const_reverse_iterator
+            crend() const
+            /// Const reverse iterator.  Points to end of reversed range.
+            {
+                return this->rend();
+            }
+
+            std::vector<std::int8_t>
+            copy() const
+            /// Return copy of the view as std::vector<std::int8_t>
+            {
+                return std::vector<std::int8_t>(this->cbegin(), this->cend());
+            }
+
+            friend void
+            swap(col_view_& a, col_view_& b)
+            /// Allow swap via argument-dependent lookup, or "ADL"
+            {
+                auto bi = b.begin();
+                for (auto ai = a.begin(); ai != a.end(); ++ai, ++bi)
+                    {
+                        std::swap(*ai, *bi);
+                    }
+            }
+        };
+    }
+}
+
+#endif

--- a/examples/Makefile.in
+++ b/examples/Makefile.in
@@ -357,7 +357,6 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
-runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -60,7 +60,10 @@ libsequence_la_SOURCES=  Grantham.cc\
 	SummStats/lHaf.cc \
 	SummStats/variantCounts.cc \
 	SummStats/classic.cc \
-	threading.cc 
+	threading.cc \
+	variant_matrix/VariantMatrix.cc \
+	variant_matrix/VariantMatrixViews.cc
+
 
 AM_LDFLAGS=-version-info 20:0:0
 

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -158,7 +158,9 @@ am_libsequence_la_OBJECTS = Grantham.lo PathwayHelper.lo \
 	SummStats/SummStats.lo SummStats/nSL.lo SummStats/Garud.lo \
 	IOhelp.lo hts/bamrecord.lo hts/bamreader.lo SeqAlphabets.lo \
 	SummStats/lHaf.lo SummStats/variantCounts.lo \
-	SummStats/classic.lo threading.lo
+	SummStats/classic.lo threading.lo \
+	variant_matrix/VariantMatrix.lo \
+	variant_matrix/VariantMatrixViews.lo
 libsequence_la_OBJECTS = $(am_libsequence_la_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
@@ -344,7 +346,6 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
-runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
@@ -412,7 +413,9 @@ libsequence_la_SOURCES = Grantham.cc\
 	SummStats/lHaf.cc \
 	SummStats/variantCounts.cc \
 	SummStats/classic.cc \
-	threading.cc 
+	threading.cc \
+	variant_matrix/VariantMatrix.cc \
+	variant_matrix/VariantMatrixViews.cc
 
 
 #if DEBUG
@@ -573,6 +576,16 @@ SummStats/variantCounts.lo: SummStats/$(am__dirstamp) \
 	SummStats/$(DEPDIR)/$(am__dirstamp)
 SummStats/classic.lo: SummStats/$(am__dirstamp) \
 	SummStats/$(DEPDIR)/$(am__dirstamp)
+variant_matrix/$(am__dirstamp):
+	@$(MKDIR_P) variant_matrix
+	@: > variant_matrix/$(am__dirstamp)
+variant_matrix/$(DEPDIR)/$(am__dirstamp):
+	@$(MKDIR_P) variant_matrix/$(DEPDIR)
+	@: > variant_matrix/$(DEPDIR)/$(am__dirstamp)
+variant_matrix/VariantMatrix.lo: variant_matrix/$(am__dirstamp) \
+	variant_matrix/$(DEPDIR)/$(am__dirstamp)
+variant_matrix/VariantMatrixViews.lo: variant_matrix/$(am__dirstamp) \
+	variant_matrix/$(DEPDIR)/$(am__dirstamp)
 
 libsequence.la: $(libsequence_la_OBJECTS) $(libsequence_la_DEPENDENCIES) $(EXTRA_libsequence_la_DEPENDENCIES) 
 	$(AM_V_CXXLD)$(CXXLINK) -rpath $(libdir) $(libsequence_la_OBJECTS) $(libsequence_la_LIBADD) $(LIBS)
@@ -640,6 +653,8 @@ mostlyclean-compile:
 	-rm -f SummStats/*.lo
 	-rm -f hts/*.$(OBJEXT)
 	-rm -f hts/*.lo
+	-rm -f variant_matrix/*.$(OBJEXT)
+	-rm -f variant_matrix/*.lo
 
 distclean-compile:
 	-rm -f *.tab.c
@@ -703,6 +718,8 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@hts/$(DEPDIR)/samflag.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@hts/$(DEPDIR)/samfunctions.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@hts/$(DEPDIR)/samrecord.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@variant_matrix/$(DEPDIR)/VariantMatrix.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@variant_matrix/$(DEPDIR)/VariantMatrixViews.Plo@am__quote@
 
 .cc.o:
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)depbase=`echo $@ | sed 's|[^/]*$$|$(DEPDIR)/&|;s|\.o$$||'`;\
@@ -737,6 +754,7 @@ clean-libtool:
 	-rm -rf Seq/.libs Seq/_libs
 	-rm -rf SummStats/.libs SummStats/_libs
 	-rm -rf hts/.libs hts/_libs
+	-rm -rf variant_matrix/.libs variant_matrix/_libs
 
 ID: $(am__tagged_files)
 	$(am__define_uniq_tagged_files); mkid -fID $$unique
@@ -863,6 +881,8 @@ distclean-generic:
 	-rm -f SummStats/$(am__dirstamp)
 	-rm -f hts/$(DEPDIR)/$(am__dirstamp)
 	-rm -f hts/$(am__dirstamp)
+	-rm -f variant_matrix/$(DEPDIR)/$(am__dirstamp)
+	-rm -f variant_matrix/$(am__dirstamp)
 
 maintainer-clean-generic:
 	@echo "This command is intended for maintainers to use"
@@ -873,7 +893,7 @@ clean-am: clean-binPROGRAMS clean-generic clean-libLTLIBRARIES \
 	clean-libtool mostlyclean-am
 
 distclean: distclean-am
-	-rm -rf ./$(DEPDIR) Coalescent/$(DEPDIR) Seq/$(DEPDIR) SummStats/$(DEPDIR) hts/$(DEPDIR)
+	-rm -rf ./$(DEPDIR) Coalescent/$(DEPDIR) Seq/$(DEPDIR) SummStats/$(DEPDIR) hts/$(DEPDIR) variant_matrix/$(DEPDIR)
 	-rm -f Makefile
 distclean-am: clean-am distclean-compile distclean-generic \
 	distclean-tags
@@ -919,7 +939,7 @@ install-ps-am:
 installcheck-am:
 
 maintainer-clean: maintainer-clean-am
-	-rm -rf ./$(DEPDIR) Coalescent/$(DEPDIR) Seq/$(DEPDIR) SummStats/$(DEPDIR) hts/$(DEPDIR)
+	-rm -rf ./$(DEPDIR) Coalescent/$(DEPDIR) Seq/$(DEPDIR) SummStats/$(DEPDIR) hts/$(DEPDIR) variant_matrix/$(DEPDIR)
 	-rm -f Makefile
 maintainer-clean-am: distclean-am maintainer-clean-generic
 

--- a/src/variant_matrix/VariantMatrix.cc
+++ b/src/variant_matrix/VariantMatrix.cc
@@ -1,0 +1,34 @@
+#include <Sequence/VariantMatrix.hpp>
+#include <iostream>
+
+namespace Sequence
+{
+	const std::int8_t VariantMatrix::mask=std::numeric_limits<std::int8_t>::min();
+    // Non range-checked access
+    std::int8_t&
+    VariantMatrix::get(const std::size_t site, const std::size_t haplotype)
+    {
+        return data[site * nsam + haplotype];
+    }
+
+    const std::int8_t&
+    VariantMatrix::get(const std::size_t site,
+                       const std::size_t haplotype) const
+    {
+        return data[site * nsam + haplotype];
+    }
+
+    // Ranged-checked access after std::vector<T>::at.
+    std::int8_t&
+    VariantMatrix::at(const std::size_t site, const std::size_t haplotype)
+    {
+        return data.at(site * nsam + haplotype);
+    }
+
+    const std::int8_t&
+    VariantMatrix::at(const std::size_t site,
+                      const std::size_t haplotype) const
+    {
+        return data.at(site * nsam + haplotype);
+    }
+}

--- a/src/variant_matrix/VariantMatrixViews.cc
+++ b/src/variant_matrix/VariantMatrixViews.cc
@@ -1,0 +1,75 @@
+#include <Sequence/VariantMatrixViews.hpp>
+#include <stdexcept>
+
+namespace
+{
+    template <typename T, typename VM>
+    T
+    row_view_wrapper(VM& m, const std::size_t row)
+    {
+        if (row >= m.nsites)
+            {
+                throw std::out_of_range("row index out of range");
+            }
+        return T(m.data.data() + row * m.nsam, m.nsam);
+    }
+    template <typename T, typename VM>
+    T
+    col_view_wrapper(VM& m, const std::size_t col)
+    {
+        if (col >= m.nsam)
+            {
+                throw std::out_of_range("column index out of range");
+            }
+        return T(m.data.data() + col, m.nsam * m.nsites, m.nsam);
+    }
+}
+
+namespace Sequence
+{
+
+    ConstRowView
+    get_RowView(const VariantMatrix& m, const std::size_t row)
+    {
+        return row_view_wrapper<ConstRowView>(m, row);
+    }
+
+    RowView
+    get_RowView(VariantMatrix& m, const std::size_t row)
+    {
+        return row_view_wrapper<RowView>(m, row);
+    }
+
+    ConstRowView
+    get_ConstRowView(const VariantMatrix& m, const std::size_t row)
+    {
+        return row_view_wrapper<ConstRowView>(m, row);
+    }
+
+    ConstRowView
+    get_ConstRowView(VariantMatrix& m, const std::size_t row)
+    {
+        return row_view_wrapper<ConstRowView>(m, row);
+    }
+
+    ColView
+    get_ColView(VariantMatrix& m, const std::size_t col)
+    {
+        return col_view_wrapper<ColView>(m, col);
+    }
+    ConstColView
+    get_ColView(const VariantMatrix& m, const std::size_t col)
+    {
+        return col_view_wrapper<ConstColView>(m, col);
+    }
+    ConstColView
+    get_ConstColView(VariantMatrix& m, const std::size_t col)
+    {
+        return col_view_wrapper<ConstColView>(m, col);
+    }
+    ConstColView
+    get_ConstColView(const VariantMatrix& m, const std::size_t col)
+    {
+        return col_view_wrapper<ConstColView>(m, col);
+    }
+}

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -673,7 +673,6 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
-runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@


### PR DESCRIPTION
This PR adds a new class, Sequence::VariantMatrix, that will be much more efficient than the current PolyTable class hierarchy.  It will also be directly compatible with types from [msprime](https://github.com/jeromekelleher/msprime) and [scikit-allel](https://scikit-allel.readthedocs.io/en/latest/).

This PR is part of a major refactoring of how variation data are handled in libsequence, and how summary statistics from such data are calculated.  See the Projects page for details.
