### PR TITLE
mark as deprecated various things to remove by a 2.0 release

### DIFF
--- a/Sequence/Coalescent/FragmentsRescaling.hpp
+++ b/Sequence/Coalescent/FragmentsRescaling.hpp
@@ -27,7 +27,7 @@ namespace Sequence
 			  std::vector< std::pair<double,double> > * mutation_scale );
     void rescale_mutation_positions(Sequence::SimData * d,
 				    const std::vector< std::pair<double,double> > & sample_scale, 
-				    const std::vector< std::pair<double,double> > & mutation_scale );
+				    const std::vector< std::pair<double,double> > & mutation_scale )__attribute__((deprecated));
     void rescale_arg( arg * sample_history,
 		    const std::vector< std::pair<int,int> > & fragments );
     double integrate_genetic_map( const std::vector<chromosome> & sample,

--- a/Sequence/Coalescent/Mutation.hpp
+++ b/Sequence/Coalescent/Mutation.hpp
@@ -103,7 +103,7 @@ namespace Sequence
 				     uniform_generator & uni,
 				     const int & nsites,
 				     const arg & history,
-				     const double & theta);
+				     const double & theta)__attribute((deprecated));
 
     template<typename poisson_generator,
 	     typename uniform_generator>
@@ -111,21 +111,21 @@ namespace Sequence
 				     const uniform_generator & uni,
 				     const int & nsites,
 				     const arg & history,
-				     const double & theta);
+				     const double & theta)__attribute__((deprecated));
  
     template<typename uniform_generator>
     SimData infinite_sites_sim_data( uniform_generator & uni,
 				     const int & nsites,
 				     const arg & history,
 				     const double * total_times,
-				     const unsigned * segsites);
+				     const unsigned * segsites)__attribute__((deprecated));
 
     template<typename uniform_generator>
     SimData infinite_sites_sim_data( const uniform_generator & uni,
 				     const int & nsites,
 				     const arg & history,
 				     const double * total_times,
-				     const unsigned * segsites);
+				     const unsigned * segsites)__attribute__((deprecated));
 
     void output_gametes(FILE * fp,const unsigned & segsites,
 			const unsigned & nsam,

--- a/Sequence/Coalescent/NeutralSample.hpp
+++ b/Sequence/Coalescent/NeutralSample.hpp
@@ -25,7 +25,7 @@ namespace Sequence
 				      std::vector<chromosome> * sample,
 				      arg * sample_history,
 				      unsigned * max_chromosomes = NULL,
-				      const unsigned & max_chromosomes_inc = 0)__attribute__((deprecated))
+				      const unsigned & max_chromosomes_inc = 0)
     /*!
       @brief A simple function to generate samples under a neutral equilibrium model.
 

--- a/Sequence/Coalescent/NeutralSample.hpp
+++ b/Sequence/Coalescent/NeutralSample.hpp
@@ -25,7 +25,7 @@ namespace Sequence
 				      std::vector<chromosome> * sample,
 				      arg * sample_history,
 				      unsigned * max_chromosomes = NULL,
-				      const unsigned & max_chromosomes_inc = 0)
+				      const unsigned & max_chromosomes_inc = 0)__attribute__((deprecated))
     /*!
       @brief A simple function to generate samples under a neutral equilibrium model.
 

--- a/Sequence/FST.hpp
+++ b/Sequence/FST.hpp
@@ -38,7 +38,7 @@ namespace Sequence
 {
   class PolyTable;
   struct FSTimpl;
-  class FST 
+  class __attribute__ ((deprecated)) FST 
   {
   private:
     std::unique_ptr<FSTimpl> impl;

--- a/Sequence/PolyFunctional.hpp
+++ b/Sequence/PolyFunctional.hpp
@@ -42,7 +42,7 @@ long with libsequence.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace Sequence
 {
-  struct countStates
+  struct __attribute__ ((deprecated)) countStates
   /*!
     \brief Functor to count the number of states, excluding gaps and missing data,
     in a range of characters.
@@ -149,7 +149,7 @@ namespace Sequence
     \endcode
     \brief Calculate nucleotide diversity from a polymorphic site
   */
-  struct ssh : public std::binary_function< double,polymorphicSite,double >
+  struct __attribute__ ((deprecated)) ssh : public std::binary_function< double,polymorphicSite,double >
 
   {
     inline double operator()( double & _ssh,

--- a/Sequence/PolySIM.hpp
+++ b/Sequence/PolySIM.hpp
@@ -43,7 +43,7 @@ long with libsequence.  If not, see <http://www.gnu.org/licenses/>.
 namespace Sequence
   {
   class SimData;
-  class PolySIM : public PolySNP
+  class __attribute__ ((deprecated)) PolySIM : public PolySNP
     {
     private:
       //functions for Hudson's Partition Test

--- a/Sequence/PolySNP.hpp
+++ b/Sequence/PolySNP.hpp
@@ -81,7 +81,7 @@ long with libsequence.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace Sequence 
   {
-    class PolyTable;
+    class __attribute__ ((deprecated)) PolyTable;
     struct _PolySNPImpl;
     class PolySNP 
     {

--- a/Sequence/PolyTable.hpp
+++ b/Sequence/PolyTable.hpp
@@ -57,41 +57,42 @@ long with libsequence.  If not, see <http://www.gnu.org/licenses/>.
 /*! \example PolyTableIterators.cc */
 namespace Sequence
 {
-  class PolyTable 
-  {
-  private:
-    struct PolyTableImpl;
-    std::unique_ptr<PolyTableImpl> impl;
-  public:
-    //! Data type to store site positions
-    using pos_container_t = std::vector<double>;
-    //! Data type for storing genotypes
-    using geno_container_t = std::vector<std::string>;
-    
-    //typedefs for container types
-    //! \brief non-const reference to std::string
-    using reference = geno_container_t::reference;
-    //! \brief const reference to std::string
-    using const_reference = geno_container_t::const_reference;
-    //! \brief The size_type for the haplotype vector
-    using size_type = geno_container_t::size_type;
-    /*!
+    class __attribute__((deprecated)) PolyTable
+    {
+      private:
+        struct PolyTableImpl;
+        std::unique_ptr<PolyTableImpl> impl;
+
+      public:
+        //! Data type to store site positions
+        using pos_container_t = std::vector<double>;
+        //! Data type for storing genotypes
+        using geno_container_t = std::vector<std::string>;
+
+        //typedefs for container types
+        //! \brief non-const reference to std::string
+        using reference = geno_container_t::reference;
+        //! \brief const reference to std::string
+        using const_reference = geno_container_t::const_reference;
+        //! \brief The size_type for the haplotype vector
+        using size_type = geno_container_t::size_type;
+        /*!
       \brief non-const iterator to the haplotypes
     */
-    using data_iterator = geno_container_t::iterator;
-    /*!
+        using data_iterator = geno_container_t::iterator;
+        /*!
       \brief const iterator to the haplotypes
     */
-    using const_data_iterator = geno_container_t::const_iterator;
-    /*!
+        using const_data_iterator = geno_container_t::const_iterator;
+        /*!
       \brief non-const iterator to the positions
     */
-    using pos_iterator =  std::vector<double>::iterator;
-    /*!
+        using pos_iterator = std::vector<double>::iterator;
+        /*!
       \brief const iterator to the positions
     */
-    using const_pos_iterator = std::vector<double>::const_iterator;
-    /*! \brief Const iterator to segregating sites
+        using const_pos_iterator = std::vector<double>::const_iterator;
+        /*! \brief Const iterator to segregating sites
       Const iterator to segregating sites. The value_type of this
       iterator is const std::pair<double,std::string>, where the 
       double is the position of the segregating site, and the
@@ -99,83 +100,83 @@ namespace Sequence
       in the string corresponds to the state of the first character
       in the PolyTable (i.e. (*this)[0]), etc.
     */
-    using const_site_iterator = Sequence::polySiteVector::const_iterator;
-    using row_t = geno_container_t::value_type;
-    using column_t = const_site_iterator::value_type;
-    //functions to return iterators
-    //! \return an iterator pointing to the first "haplotype"
-    data_iterator begin();
-    //! \return an iterator pointing the end of the "haplotypes"
-    data_iterator end();
-    //! \return a const iterator pointing to the first "haplotype"
-    const_data_iterator begin() const;
-    //! \return a const iterator pointing the end of the "haplotypes"
-    const_data_iterator end() const;
-    //! \return a const iterator pointing to the first "haplotype"
-    const_data_iterator cbegin() const;
-    //! \return a const iterator pointing the end of the "haplotypes"
-    const_data_iterator cend() const;
-    //! \return iterator to first position
-    pos_iterator pbegin();
-    //! \return iterator to end of positions
-    pos_iterator pend();
-    //! \return const iterator to first position
-    const_pos_iterator pbegin() const;
-    //! \return const iterator to end of positions
-    const_pos_iterator pend() const;
-    //! \return const iterator to first position
-    const_pos_iterator pcbegin() const;
-    //! \return const iterator to end of positions
-    const_pos_iterator pcend() const;
-    //! \return const iterator to first column (position, variants)
-    const_site_iterator sbegin() const;
-    //! \return const iterator to end of columns
-    const_site_iterator send() const;
-    //! \return const iterator to first column (position, variants)
-    const_site_iterator scbegin() const;
-    //! \return const iterator to first column (position, variants)
-    const_site_iterator scend() const;
+        using const_site_iterator = Sequence::polySiteVector::const_iterator;
+        using row_t = geno_container_t::value_type;
+        using column_t = const_site_iterator::value_type;
+        //functions to return iterators
+        //! \return an iterator pointing to the first "haplotype"
+        data_iterator begin();
+        //! \return an iterator pointing the end of the "haplotypes"
+        data_iterator end();
+        //! \return a const iterator pointing to the first "haplotype"
+        const_data_iterator begin() const;
+        //! \return a const iterator pointing the end of the "haplotypes"
+        const_data_iterator end() const;
+        //! \return a const iterator pointing to the first "haplotype"
+        const_data_iterator cbegin() const;
+        //! \return a const iterator pointing the end of the "haplotypes"
+        const_data_iterator cend() const;
+        //! \return iterator to first position
+        pos_iterator pbegin();
+        //! \return iterator to end of positions
+        pos_iterator pend();
+        //! \return const iterator to first position
+        const_pos_iterator pbegin() const;
+        //! \return const iterator to end of positions
+        const_pos_iterator pend() const;
+        //! \return const iterator to first position
+        const_pos_iterator pcbegin() const;
+        //! \return const iterator to end of positions
+        const_pos_iterator pcend() const;
+        //! \return const iterator to first column (position, variants)
+        const_site_iterator sbegin() const;
+        //! \return const iterator to end of columns
+        const_site_iterator send() const;
+        //! \return const iterator to first column (position, variants)
+        const_site_iterator scbegin() const;
+        //! \return const iterator to first column (position, variants)
+        const_site_iterator scend() const;
 
-    //constructor types
-    explicit PolyTable();
-    explicit PolyTable(PolyTable::const_site_iterator beg,
-		       PolyTable::const_site_iterator end);
-    explicit PolyTable( std::vector<double> __positions,
-			std::vector<std::string> __data );
-    PolyTable(PolyTable &&);
-    PolyTable(const PolyTable &);
-    virtual ~ PolyTable (void);
+        //constructor types
+        explicit PolyTable();
+        explicit PolyTable(PolyTable::const_site_iterator beg,
+                           PolyTable::const_site_iterator end);
+        explicit PolyTable(std::vector<double> __positions,
+                           std::vector<std::string> __data);
+        PolyTable(PolyTable &&);
+        PolyTable(const PolyTable &);
+        virtual ~PolyTable(void);
 
-    //! Convenience function to return site positions
-    std::vector < double > GetPositions (void) const;
-    //! Conventience function to return data.  Each string is a "haplotype".
-    std::vector < std::string > GetData (void) const;
-    
-    //operators and implicit typecasts
+        //! Convenience function to return site positions
+        std::vector<double> GetPositions(void) const;
+        //! Conventience function to return data.  Each string is a "haplotype".
+        std::vector<std::string> GetData(void) const;
 
-    //! Comparison operator.  Case-sensitive
-    virtual bool operator==(const PolyTable &rhs) const;
-    //! Not-equal operator. Case-sensitive
-    virtual bool operator!=(const PolyTable &rhs) const;
-    //! Move assignment
-    PolyTable & operator=(PolyTable &&);
-    //! Copy assignment
-    PolyTable & operator=(const PolyTable &);
-    /*!
+        //operators and implicit typecasts
+
+        //! Comparison operator.  Case-sensitive
+        virtual bool operator==(const PolyTable &rhs) const;
+        //! Not-equal operator. Case-sensitive
+        virtual bool operator!=(const PolyTable &rhs) const;
+        //! Move assignment
+        PolyTable &operator=(PolyTable &&);
+        //! Copy assignment
+        PolyTable &operator=(const PolyTable &);
+        /*!
       Return the i-th element of PolyTable::data.
       \note range-checking done by assert()
     */
-    const_reference operator[] (const size_type & i) const;
-    /*!
+        const_reference operator[](const size_type &i) const;
+        /*!
       Return the i-th element of PolyTable::data.
       \note range-checking done by assert()
     */
-    reference operator[] (const size_type & i);
-    
-    //! \return true if object contains no data, false otherwise
-    bool empty() const;
+        reference operator[](const size_type &i);
 
-    /*!
+        //! \return true if object contains no data, false otherwise
+        bool empty() const;
+
+        /*!
       Assignment operation, allowing a range of polymorphic sites
       to be assigned to a polymorphism table.  This exists mainly
       for two purposes. One is the ability to assign tables from 
@@ -185,62 +186,62 @@ namespace Sequence
       The only case where false is returned is if the number of individuals
       at each site is not the constant from beg to end.
     */
-    bool assign(PolyTable::const_site_iterator beg,
-		PolyTable::const_site_iterator end);
+        bool assign(PolyTable::const_site_iterator beg,
+                    PolyTable::const_site_iterator end);
 
-    //Swap data with another PolyTable
-    void swap( PolyTable & );
-    /*!
+        //Swap data with another PolyTable
+        void swap(PolyTable &);
+        /*!
       Assign data to object
       \return true if successful
     */
-    bool assign( const std::vector<double> & __positions,
-		 const std::vector<std::string> & __data );
-    /*!
+        bool assign(const std::vector<double> &__positions,
+                    const std::vector<std::string> &__data);
+        /*!
       Move data to object
       \return true if successful
     */
-    bool assign( std::vector<double> && __positions,
-		 std::vector<std::string> && __data );
+        bool assign(std::vector<double> &&__positions,
+                    std::vector<std::string> &&__data);
 
-    //! \return Sample size
-    size_type size (void) const;
+        //! \return Sample size
+        size_type size(void) const;
 
-    //! \return the i-th position from the PolyTable::positions.
-    double position (const std::vector<double>::size_type & i) const;
+        //! \return the i-th position from the PolyTable::positions.
+        double position(const std::vector<double>::size_type &i) const;
 
-    //! \return the number of positions (columns)
-    unsigned numsites (void) const;
+        //! \return the number of positions (columns)
+        unsigned numsites(void) const;
 
-    /*!
+        /*!
       read is a pure virtual function.
       Calls to istream & operator>> (istream & s, PolyTable & c)
       act via this routine, which must be defined in all
       derived classes
     */
-    virtual std::istream & read(std::istream &h) = 0;
+        virtual std::istream &read(std::istream &h) = 0;
 
-    /*!
+        /*!
       print is a pure virtual function.
       Calls to ostream & operator<<(ostream & s, PolyTable & c)
       act via this routine, which must be defined in all
       derived classes
     */
-    virtual std::ostream & print(std::ostream &h) const = 0;
-  };
+        virtual std::ostream &print(std::ostream &h) const = 0;
+    };
 
-  /*!
+    /*!
     \ingroup operators
     Allows objects derived from Sequence::PolyTable
     to be read in from streams
   */
-  std::istream & operator>> (std::istream & s, PolyTable & c);
+    std::istream &operator>>(std::istream &s, PolyTable &c);
 
-  /*!
+    /*!
     \ingroup operators
     Allows objects derived from Sequence::PolyTable
     to be written out to streams
-  */  
-  std::ostream & operator<< (std::ostream & o, const PolyTable & c);
+  */
+    std::ostream &operator<<(std::ostream &o, const PolyTable &c);
 }
 #endif

--- a/Sequence/PolyTableFunctions.hpp
+++ b/Sequence/PolyTableFunctions.hpp
@@ -38,7 +38,7 @@
 namespace Sequence
 {
   //! \return true if \a t contains \a ch, false otherwise
-  bool containsCharacter(const PolyTable * t,const char ch);
+  bool containsCharacter(const PolyTable * t,const char ch)__attribute__ ((deprecated));
 
   /*!
     \return true if the following conditions are met : First, the length of every
@@ -52,7 +52,7 @@ namespace Sequence
     routine can be thought of as a PolyTable equivalent to Alignment::validForPolyAnalysis,
     which works on ranges of Sequence::Seq objects.
   */
-  bool polyTableValid(const PolyTable * t);
+  bool polyTableValid(const PolyTable * t)__attribute__ ((deprecated));
 
   template<typename T> T copyPolyTable(const T & t)
   {
@@ -60,18 +60,18 @@ namespace Sequence
 	     std::vector<std::string>(t.begin(),t.end()));
   }
   
-  template<typename T,typename F> T removeColumns( const T & t, const F & f, const bool skipAnc = false, const unsigned anc = 0,const char gapchar = '-' );
-  template<typename T> T removeGaps( const T & t, const bool skipAnc = false, const unsigned anc = 0,const char gapchar = '-' );
+  template<typename T,typename F> T removeColumns( const T & t, const F & f, const bool skipAnc = false, const unsigned anc = 0,const char gapchar = '-' )__attribute__ ((deprecated));
+  template<typename T> T removeGaps( const T & t, const bool skipAnc = false, const unsigned anc = 0,const char gapchar = '-' )__attribute__ ((deprecated));
   template<typename T> T removeInvariantPos(const T & t, const bool skipAnc = false, const unsigned anc = 0,
-					    const char gapchar = '-');
+					    const char gapchar = '-')__attribute__ ((deprecated));
   template<typename T> T removeAmbiguous(const T & t, const bool skipAnc = false, const unsigned anc = 0,
-					 const char gapchar = '-');
+					 const char gapchar = '-')__attribute__ ((deprecated));
   template<typename T> T removeMissing(const T & t, const bool skipAnc = false, const unsigned anc = 0,
-				       const char gapchar = '-');
+				       const char gapchar = '-')__attribute__ ((deprecated));
   template<typename T> T removeMultiHits(const T & t, const bool skipAnc = false, const unsigned anc = 0,
-					 const char gapchar = '-');
-  template<typename T> T polyTableToBinary(const T & t, const unsigned ref = 0, const char gapchar = '-');
-  template<typename T> T polyTableFreqFilter(const T & t, const unsigned mincount,const bool skipAnc = false, const unsigned anc = 0 , const char gapchar = '-');
+					 const char gapchar = '-')__attribute__ ((deprecated));
+  template<typename T> T polyTableToBinary(const T & t, const unsigned ref = 0, const char gapchar = '-')__attribute__ ((deprecated));
+  template<typename T> T polyTableFreqFilter(const T & t, const unsigned mincount,const bool skipAnc = false, const unsigned anc = 0 , const char gapchar = '-')__attribute__ ((deprecated));
 }
 #include <Sequence/bits/PolyTableFunctions.tcc>
 #endif

--- a/Sequence/Recombination.hpp
+++ b/Sequence/Recombination.hpp
@@ -75,7 +75,7 @@ namespace Sequence
     namespace Recombination
     {
         double HudsonsC(const Sequence::PolyTable *data,
-                        const bool &haveOutgroup, const unsigned &outgroup);
+                        const bool &haveOutgroup, const unsigned &outgroup)__attribute__ ((deprecated));
         /*!
 		 * \brief Calculate pairwise LD for a Sequence::PolyTable
 		 *
@@ -96,7 +96,7 @@ namespace Sequence
         std::vector<PairwiseLDstats> Disequilibrium(
             const Sequence::PolyTable *data, const bool &haveOutgroup = false,
             const unsigned &outgroup = 0, const unsigned &mincount = 1,
-            const double max_distance = std::numeric_limits<double>::max());
+            const double max_distance = std::numeric_limits<double>::max())__attribute__ ((deprecated));
 
         /*!
          Calculates LD statistics for sites i and j, where j>1.
@@ -118,7 +118,7 @@ namespace Sequence
                                    const unsigned &outgroup = 0,
                                    const unsigned &mincount = 1,
                                    const double max_distance
-                                   = std::numeric_limits<double>::max());
+                                   = std::numeric_limits<double>::max())__attribute__ ((deprecated));
     }
 }
 #endif

--- a/Sequence/SimData.hpp
+++ b/Sequence/SimData.hpp
@@ -65,30 +65,29 @@ fall in the interval (0,1].
 #include <Sequence/PolyTable.hpp>
 #include <cstdio>
 namespace Sequence
-  {
-  class SimData:public PolyTable
+{
+    class __attribute__((deprecated)) SimData : public PolyTable
     {
-    public:
-      SimData(void);
-      SimData( SimData && );
-      SimData( const SimData & );
-      //SimData( SimData & );// = default;
-      //explicit SimData (const size_t & nsam=0, const size_t & nsnps = 0);
-      //SimData(double *pos, const char **sample, const unsigned &  nsam, const unsigned & S);
-      //SimData(const std::vector<double> & pos, const std::vector<std::string> & data);
-      SimData(std::vector<double> pos,  std::vector<std::string> data);
-      SimData(const SimData::const_site_iterator & beg, 
-	      const SimData::const_site_iterator & end);
-      
-      ~ SimData (void){}
-      
-      SimData & operator=(SimData &&);
-      SimData & operator=(const SimData &);
+      public:
+        SimData(void);
+        SimData(SimData &&);
+        SimData(const SimData &);
+        //SimData( SimData & );// = default;
+        //explicit SimData (const size_t & nsam=0, const size_t & nsnps = 0);
+        //SimData(double *pos, const char **sample, const unsigned &  nsam, const unsigned & S);
+        //SimData(const std::vector<double> & pos, const std::vector<std::string> & data);
+        SimData(std::vector<double> pos, std::vector<std::string> data);
+        SimData(const SimData::const_site_iterator &beg,
+                const SimData::const_site_iterator &end);
 
-      virtual std::istream & read (std::istream & s) ;
-      virtual std::ostream & print(std::ostream &o) const;
-      virtual int fromfile( FILE * openedfile );
+        ~SimData(void) {}
+
+        SimData &operator=(SimData &&);
+        SimData &operator=(const SimData &);
+
+        virtual std::istream &read(std::istream &s);
+        virtual std::ostream &print(std::ostream &o) const;
+        virtual int fromfile(FILE *openedfile);
     };
-
 }
 #endif

--- a/Sequence/SimDataIO.hpp
+++ b/Sequence/SimDataIO.hpp
@@ -15,7 +15,7 @@ namespace Sequence
     Write a SimData object to a gzFile object (from the C-language zlib library)
     Returns the amount of data written, or -1 on error.
    */
-  long long write_SimData_gz( gzFile & file, const SimData & d, const bool & binary = false);
+  long long write_SimData_gz( gzFile & file, const SimData & d, const bool & binary = false)__attribute__ ((deprecated));
 
   /*! \brief Read a SimData object from a gzFile
     Read a SimData object from a gzFile object (from the C-language zlib library)
@@ -25,7 +25,7 @@ namespace Sequence
     then you cannot expect to use this function to read in the data, and you 
     should use a boost filtering_istream instead.
    */
-  SimData read_SimData_gz( gzFile & file, const bool & binary = false );
+  SimData read_SimData_gz( gzFile & file, const bool & binary = false )__attribute__ ((deprecated));
 
   /*! \brief Write a SimData object in binary format to an ostream.
     Write a SimData object in binary format to an ostream.
@@ -39,7 +39,7 @@ namespace Sequence
     nsites_i values (uint32_t) representing the indexes (from 0 to nsites-1) where the derived mutations are
     on haplotype i
   */
-  void write_SimData_binary( std::ostream & o, const SimData & d );
+  void write_SimData_binary( std::ostream & o, const SimData & d )__attribute__ ((deprecated));
 
   /*!
     Read a SimData object in binary format from an istream
@@ -53,7 +53,7 @@ namespace Sequence
     nsites_i unsigned values representing the indexes (from 0 to nsites-1) where the derived mutations are
     on haplotype i
   */
-  SimData read_SimData_binary( std::istream & i );
+  SimData read_SimData_binary( std::istream & i )__attribute__ ((deprecated));
 
   /*! \brief  Write a SimData object in binary format to a C-style file descriptor
     Write a SimData object in binary format to a C-style file descriptor
@@ -67,7 +67,7 @@ namespace Sequence
     nsites_i values (uint32_t) representing the indexes (from 0 to nsites-1) where the derived mutations are
     on haplotype i
    */
-  long int write_SimData_binary( int fd , const SimData & d );
+  long int write_SimData_binary( int fd , const SimData & d )__attribute__ ((deprecated));
 
   /*! \brief Write a SimData object in binary format to a C-style file pointer
     Write a SimData object in binary format to a C-style file pointer
@@ -81,7 +81,7 @@ namespace Sequence
     nsites_i values (uint32_t) representing the indexes (from 0 to nsites-1) where the derived mutations are
     on haplotype i
    */
-  long int write_SimData_binary( FILE * fp , const SimData & d );
+  long int write_SimData_binary( FILE * fp , const SimData & d )__attribute__ ((deprecated));
 }
 
 #endif

--- a/Sequence/SimpleSNP.hpp
+++ b/Sequence/SimpleSNP.hpp
@@ -63,18 +63,20 @@ long with libsequence.  If not, see <http://www.gnu.org/licenses/>.
 #include <Sequence/PolyTable.hpp>
 
 namespace Sequence
-  {
-  class SimpleSNP:public PolyTable
+{
+    class __attribute__((deprecated)) SimpleSNP : public PolyTable
     {
-    private:
-      std::vector<std::string> _names;
-      bool Diploid,isoFemale;
-      bool haveOutgroup;
-    public:
-      SimpleSNP( SimpleSNP && );
-      SimpleSNP (const bool diploid =0,const bool isofemale=0)  : PolyTable(),
-          Diploid(diploid),isoFemale(isofemale),haveOutgroup(false)
-          /*!
+      private:
+        std::vector<std::string> _names;
+        bool Diploid, isoFemale;
+        bool haveOutgroup;
+
+      public:
+        SimpleSNP(SimpleSNP &&);
+        SimpleSNP(const bool diploid = 0, const bool isofemale = 0)
+            : PolyTable(), Diploid(diploid), isoFemale(isofemale),
+              haveOutgroup(false)
+        /*!
           The two bools that this constructor takes allow you to deal
           with two very different types of polymorphism data.  If both
           bools are set to 0 (the default), the data are simply read in
@@ -92,16 +94,17 @@ namespace Sequence
           found, one of the two possible states will be assigned randomly
           (NOT IMPLEMENTED YET!)
           */
-      {}
-      ~ SimpleSNP (void) {}
-     
-      SimpleSNP & operator=(SimpleSNP &&);
+        {
+        }
+        ~SimpleSNP(void) {}
 
-      bool outgroup(void) const;
-      void set_outgroup( const bool & b );
-      std::string label(unsigned i) const;
-      std::istream & read (std::istream & s) ;
-      std::ostream & print(std::ostream &o) const;
+        SimpleSNP &operator=(SimpleSNP &&);
+
+        bool outgroup(void) const;
+        void set_outgroup(const bool &b);
+        std::string label(unsigned i) const;
+        std::istream &read(std::istream &s);
+        std::ostream &print(std::ostream &o) const;
     };
     typedef SimpleSNP Hudson2001;
 }

--- a/Sequence/SummStats/Garud.hpp
+++ b/Sequence/SummStats/Garud.hpp
@@ -24,7 +24,7 @@ namespace Sequence
     \ingroup popgenanalysis
     \return An object of type Sequence::GarudStats
   */
-  GarudStats H1H12(const SimData & d);
+  GarudStats H1H12(const SimData & d)__attribute__ ((deprecated));
 }
 
 #endif

--- a/Sequence/SummStats/Snn.hpp
+++ b/Sequence/SummStats/Snn.hpp
@@ -39,7 +39,7 @@ namespace Sequence
 			const std::vector< std::vector<double> > & dkj,
 			const unsigned config[],
 			const size_t & npop,
-			const unsigned & nsam );
+			const unsigned & nsam )__attribute__ ((deprecated));
   
   template< typename shuffler >
   std::pair<double,double>
@@ -47,7 +47,7 @@ namespace Sequence
 	   const unsigned config[],
 	   const size_t & npop,
 	   shuffler & s,
-	   const unsigned & nperms = 10000);
+	   const unsigned & nperms = 10000)__attribute__ ((deprecated));
 
   template< typename shuffler >
   std::vector< std::vector<double> >
@@ -55,7 +55,7 @@ namespace Sequence
 		    const unsigned config[],
 		    const size_t & npop,
 		    shuffler & s,
-		    const unsigned & nperms = 10000);
+		    const unsigned & nperms = 10000)__attribute__ ((deprecated));
 }
 #endif
 #include <Sequence/bits/Snn.tcc>

--- a/Sequence/SummStats/nSL.hpp
+++ b/Sequence/SummStats/nSL.hpp
@@ -29,7 +29,7 @@ namespace Sequence
     std::pair<double, double>
     nSL(const std::size_t &core, const SimData &d,
         const std::unordered_map<double, double> &gmap
-        = std::unordered_map<double, double>());
+        = std::unordered_map<double, double>())__attribute__ ((deprecated));
 
     /*!
      * Threaded implementation of the nSL statistic. See \ref threads.
@@ -39,7 +39,7 @@ namespace Sequence
      */
     std::vector<std::tuple<double, double, std::uint32_t>>
     nSL_t(const SimData &d, const std::unordered_map<double, double> &gmap
-                            = std::unordered_map<double, double>());
+                            = std::unordered_map<double, double>())__attribute__ ((deprecated));
 
     /*!
      * Threaded implementation of the nSL statistic. See \ref threads.
@@ -51,6 +51,6 @@ namespace Sequence
     std::vector<std::tuple<double, double, std::uint32_t>>
     nSL_t(const SimData &d, const std::vector<std::size_t> &core_snps,
           const std::unordered_map<double, double> &gmap
-          = std::unordered_map<double, double>());
+          = std::unordered_map<double, double>())__attribute__ ((deprecated));
 }
 #endif

--- a/Sequence/polySiteVector.hpp
+++ b/Sequence/polySiteVector.hpp
@@ -42,14 +42,14 @@ namespace Sequence
     a position (a double) and the characters at 
     that positions (a std::string)
   */
-  using polymorphicSite = std::pair< double, std::string >;
+  using polymorphicSite = std::pair< double, std::string >__attribute__((deprecated));
 
   /*!
     A polymorphism data set can be represented as
     a vector containing a sequence of polymorphicSite
   */
-  using polySiteVector = std::vector< polymorphicSite >;
+  using polySiteVector = std::vector< polymorphicSite >__attribute__((deprecated));
 
-  polySiteVector make_polySiteVector(const Sequence::PolyTable & data);
+  polySiteVector make_polySiteVector(const Sequence::PolyTable & data)__attribute__((deprecated));
 }
 #endif

--- a/Sequence/polySiteVector.hpp
+++ b/Sequence/polySiteVector.hpp
@@ -42,13 +42,13 @@ namespace Sequence
     a position (a double) and the characters at 
     that positions (a std::string)
   */
-  using polymorphicSite = std::pair< double, std::string >__attribute__((deprecated));
+  using polymorphicSite = std::pair< double, std::string >;
 
   /*!
     A polymorphism data set can be represented as
     a vector containing a sequence of polymorphicSite
   */
-  using polySiteVector = std::vector< polymorphicSite >__attribute__((deprecated));
+  using polySiteVector = std::vector< polymorphicSite >;
 
   polySiteVector make_polySiteVector(const Sequence::PolyTable & data)__attribute__((deprecated));
 }

--- a/Sequence/stateCounter.hpp
+++ b/Sequence/stateCounter.hpp
@@ -36,7 +36,7 @@ in an alignment, or along a sequence
 */
 namespace Sequence
   {
-    class stateCounter : public std::unary_function<char,void>
+    class __attribute__ ((deprecated))stateCounter : public std::unary_function<char,void>
     {
     public:
       typedef unsigned size_type;


### PR DESCRIPTION
This PR marks many types/functions as deprecated.  These must be removed by the time a 2.0 release is ready.