### PR TITLE
use header-only version of boost unit testing library

### DIFF
--- a/test/AlignStreamTest.cc
+++ b/test/AlignStreamTest.cc
@@ -1,11 +1,10 @@
 //! \file AlignStreamTest.cc @brief unit tests for Sequence::ClustalW and Sequence::phylipData
 #define BOOST_TEST_MODULE AlignStream
-#define BOOST_TEST_DYN_LINK
 
 #include <Sequence/Fasta.hpp>
 #include <Sequence/Clustalw.hpp>
 #include <Sequence/phylipData.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <fstream>
 #include <iostream>
 #include <unistd.h>

--- a/test/AlignmentTest.cc
+++ b/test/AlignmentTest.cc
@@ -10,11 +10,10 @@
 */
 
 #define BOOST_TEST_MODULE AlignmentTest
-#define BOOST_TEST_DYN_LINK
 
 #include <Sequence/Fasta.hpp>
 #include <Sequence/Alignment.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <vector>
 #include <fstream>
 #include <iterator>

--- a/test/ComparisonsTest.cc
+++ b/test/ComparisonsTest.cc
@@ -1,10 +1,9 @@
 //! \file ComparisonsTests.cc @brief Tests for Sequence/Comparisons.hpp
 #define BOOST_TEST_MODULE ComparisonsTest
-#define BOOST_TEST_DYN_LINK 
 
 #include <Sequence/Comparisons.hpp>
 #include <Sequence/SeqAlphabets.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <algorithm>
 #include <iterator>
 

--- a/test/CountingOperators.cc
+++ b/test/CountingOperators.cc
@@ -1,8 +1,7 @@
 #define BOOST_TEST_MODULE CountingOperators
-#define BOOST_TEST_DYN_LINK 
 
 #include <Sequence/CountingOperators.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <algorithm>
 #include <functional>
 #include <string>

--- a/test/FastaConstructors.cc
+++ b/test/FastaConstructors.cc
@@ -1,10 +1,9 @@
 //!\ file FastaConstructors.cc
 #define BOOST_TEST_MODULE FastaConstructors
-#define BOOST_TEST_DYN_LINK 
 
 #include <Sequence/Fasta.hpp>
 #include <string>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <iostream>
 #include <functional>
 

--- a/test/FastaExplicitIO.cc
+++ b/test/FastaExplicitIO.cc
@@ -1,9 +1,8 @@
 #define BOOST_TEST_MODULE FastaExplicitIO
-#define BOOST_TEST_DYN_LINK 
 
 #include <Sequence/FastaExplicit.hpp>
 #include <fstream>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <unistd.h>
 #include <iterator>
 

--- a/test/FastaIO.cc
+++ b/test/FastaIO.cc
@@ -1,10 +1,9 @@
 #define BOOST_TEST_MODULE FastaIO
-#define BOOST_TEST_DYN_LINK 
 
 #include <Sequence/Fasta.hpp>
 #include <fstream>
 #include <iostream>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <unistd.h>
 #include <iterator>
 

--- a/test/FastaOperations.cc
+++ b/test/FastaOperations.cc
@@ -1,13 +1,12 @@
 //\file FastaOperations.cc
 #define BOOST_TEST_MODULE FastaOperations
-#define BOOST_TEST_DYN_LINK 
 
 #include <Sequence/Fasta.hpp>
 #include <string>
 #include <iostream>
 #include <algorithm>
 #include <numeric>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 //A generic revcom routine written for this test
 std::string rcom( const std::string & s )

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -24,12 +24,9 @@ check_PROGRAMS=FastaConstructors FastaIO FastaExplicitIO FastaOperations \
 
 TESTS=$(check_PROGRAMS)
 
-#BOOST_LIBS=-lboost_unit_test_framework
-#	SEQUENCE=-lsequence
-
 AM_CXXFLAGS=-g
 AM_LDFLAGS=-L../src/.libs -static
-AM_LIBS=-lboost_unit_test_framework -lsequence
+AM_LIBS=-lsequence
 
 if HAVE_HTSLIB
 AM_CXXFLAGS+=-DHAVE_HTSLIB

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -683,13 +683,9 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 @BUNIT_TEST_PRESENT_TRUE@TESTS = $(check_PROGRAMS)
-
-#BOOST_LIBS=-lboost_unit_test_framework
-#	SEQUENCE=-lsequence
 @BUNIT_TEST_PRESENT_TRUE@AM_CXXFLAGS = -g $(am__append_1)
 @BUNIT_TEST_PRESENT_TRUE@AM_LDFLAGS = -L../src/.libs -static
-@BUNIT_TEST_PRESENT_TRUE@AM_LIBS = -lboost_unit_test_framework \
-@BUNIT_TEST_PRESENT_TRUE@	-lsequence $(am__append_2)
+@BUNIT_TEST_PRESENT_TRUE@AM_LIBS = -lsequence $(am__append_2)
 @BUNIT_TEST_PRESENT_TRUE@FastaConstructors_SOURCES = FastaConstructors.cc
 @BUNIT_TEST_PRESENT_TRUE@FastaIO_SOURCES = FastaIO.cc
 @BUNIT_TEST_PRESENT_TRUE@FastaExplicitIO_SOURCES = FastaIO.cc

--- a/test/PolySIMtest.cc
+++ b/test/PolySIMtest.cc
@@ -3,11 +3,10 @@
   by independently recoding them all.  Joy.
  */
 #define BOOST_TEST_MODULE PolySIMtest
-#define BOOST_TEST_DYN_LINK 
 
 #include <Sequence/SimData.hpp>
 #include <Sequence/PolySIM.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <fstream>
 #include <iostream>
 #include <set>

--- a/test/PolySNPtest.cc
+++ b/test/PolySNPtest.cc
@@ -1,9 +1,8 @@
 #define BOOST_TEST_MODULE PolySNPtest
-#define BOOST_TEST_DYN_LINK 
 
 #include <Sequence/PolySites.hpp>
 #include <Sequence/PolySNP.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <fstream>
 #include <iostream>
 #include <set>

--- a/test/PolySitesIO.cc
+++ b/test/PolySitesIO.cc
@@ -1,8 +1,7 @@
 #define BOOST_TEST_MODULE PolySitesIO
-#define BOOST_TEST_DYN_LINK 
 
 #include <Sequence/PolySites.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <sstream>
 #include <fstream>
 #include <unistd.h>

--- a/test/PolyTableBadBehavior.cc
+++ b/test/PolyTableBadBehavior.cc
@@ -8,14 +8,13 @@
  */
 
 #define BOOST_TEST_MODULE PolyTableBadBehavior
-#define BOOST_TEST_DYN_LINK 
 
 #include <Sequence/PolySites.hpp>
 #include <Sequence/Fasta.hpp>
 #include <Sequence/Alignment.hpp>
 #include <Sequence/polySiteVector.hpp>
 #include <Sequence/PolyTableFunctions.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <cstdio>
 #include <cstdlib>
 #include <cctype>

--- a/test/PolyTableConversions.cc
+++ b/test/PolyTableConversions.cc
@@ -1,5 +1,4 @@
 #define BOOST_TEST_MODULE PolyTableConversions
-#define BOOST_TEST_DYN_LINK 
 
 #include <Sequence/PolySites.hpp>
 #include <Sequence/SimpleSNP.hpp>
@@ -7,7 +6,7 @@
 #include <Sequence/Fasta.hpp>
 #include <Sequence/Alignment.hpp>
 #include <Sequence/PolyTableFunctions.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <cstdio>
 #include <cstdlib>
 #include <iostream>

--- a/test/PolyTableSliceTest.cc
+++ b/test/PolyTableSliceTest.cc
@@ -1,8 +1,7 @@
 //! \file PolyTableSliceTest.cc @brief Tests for Sequence/PolyTableSlice.hpp
 #define BOOST_TEST_MODULE ComparisonsTest
-#define BOOST_TEST_DYN_LINK
 
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <Sequence/SimData.hpp>
 #include <iostream>
 #include <Sequence/PolyTableSlice.hpp>

--- a/test/PolyTableTweaking.cc
+++ b/test/PolyTableTweaking.cc
@@ -1,11 +1,10 @@
 #define BOOST_TEST_MODULE PolyTableTweaking
-#define BOOST_TEST_DYN_LINK 
 
 #include <Sequence/PolySites.hpp>
 #include <Sequence/Fasta.hpp>
 #include <Sequence/polySiteVector.hpp>
 #include <Sequence/PolyTableFunctions.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <cstdio>
 #include <cstdlib>
 #include <cctype>

--- a/test/RedundancyCom95test.cc
+++ b/test/RedundancyCom95test.cc
@@ -1,9 +1,8 @@
 #define BOOST_TEST_MODULE RedundancyCom95
-#define BOOST_TEST_DYN_LINK 
 
 #include <Sequence/RedundancyCom95.hpp>
 #include <Sequence/SeqAlphabets.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <fstream>
 #include <iostream>
 #include <string>

--- a/test/Seq8test.cc
+++ b/test/Seq8test.cc
@@ -1,10 +1,9 @@
 /*! \file Seq8test.cc @brief Unit tests for Sequence/Seq.hpp */
 #define BOOST_TEST_MODULE Seq8test
-#define BOOST_TEST_DYN_LINK 
 
 #include <Sequence/Seq8.hpp>
 #include <Sequence/SeqExceptions.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <algorithm>
 #include <iterator>
 #include <sstream>

--- a/test/SeqConversions.cc
+++ b/test/SeqConversions.cc
@@ -1,12 +1,11 @@
 #define BOOST_TEST_MODULE SeqConverions
-#define BOOST_TEST_DYN_LINK 
 
 #include <Sequence/Fasta.hpp>
 #include <Sequence/fastq.hpp>
 #include <string>
 #include <fstream>
 #include <iostream>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 BOOST_AUTO_TEST_CASE( fastq2fasta )
 {

--- a/test/SimpleSNPIO.cc
+++ b/test/SimpleSNPIO.cc
@@ -1,9 +1,8 @@
 #define BOOST_TEST_MODULE SimpleSNPIO
-#define BOOST_TEST_DYN_LINK 
 
 #include <Sequence/PolySites.hpp>
 #include <Sequence/SimpleSNP.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <sstream>
 #include <fstream>
 #include <unistd.h>

--- a/test/alphabets.cc
+++ b/test/alphabets.cc
@@ -1,10 +1,9 @@
 /*! \file alphabets.cc @brief Unit tests for Sequence/SeqAlphabets.hpp */
 #define BOOST_TEST_MODULE alphabets
-#define BOOST_TEST_DYN_LINK 
 
 #include <Sequence/SeqAlphabets.hpp>
 #include <Sequence/Fasta.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <algorithm>
 #include <iterator>
 

--- a/test/fastqConstructors.cc
+++ b/test/fastqConstructors.cc
@@ -1,10 +1,9 @@
 //\file fastqConstructors.cc
 #define BOOST_TEST_MODULE fastqIO
-#define BOOST_TEST_DYN_LINK 
 
 #include <Sequence/fastq.hpp>
 #include <fstream>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <unistd.h>
 #include <iterator>
 #include <iostream>

--- a/test/fastqIO.cc
+++ b/test/fastqIO.cc
@@ -1,9 +1,8 @@
 #define BOOST_TEST_MODULE fastqIO
-#define BOOST_TEST_DYN_LINK 
 
 #include <Sequence/fastq.hpp>
 #include <fstream>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <unistd.h>
 #include <iterator>
 #include <iostream>

--- a/test/polySiteVectorTest.cc
+++ b/test/polySiteVectorTest.cc
@@ -1,11 +1,10 @@
 //! \file polySiteVectorTest.cc @brief Unit tests for Sequence::polySiteVector
 #define BOOST_TEST_MODULE polySiteVectorTest
-#define BOOST_TEST_DYN_LINK 
 
 #include <Sequence/polySiteVector.hpp>
 #include <Sequence/PolySites.hpp>
 #include <Sequence/SeqAlphabets.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <cstdio>
 #include <cstdlib>
 #include <cctype>

--- a/test/stateCounterTest.cc
+++ b/test/stateCounterTest.cc
@@ -1,9 +1,8 @@
 #define BOOST_TEST_MODULE stateCounterTest
-#define BOOST_TEST_DYN_LINK 
 
 #include <Sequence/stateCounter.hpp>
 #include <string>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <iostream>
 #include <algorithm>
 #include <functional>

--- a/test/testSimDataIO.cc
+++ b/test/testSimDataIO.cc
@@ -1,8 +1,7 @@
 #define BOOST_TEST_MODULE testSimDataIO
-#define BOOST_TEST_DYN_LINK 
 
 #include <Sequence/SimDataIO.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 #include <fstream>
 #include <cstdio>
 #include <sstream>


### PR DESCRIPTION
This PR changes the unit testing suite to use the header-only version of boost's unit_test library.  This change will solve problems that can arise due to the runtime library being compiled with an compiler incompatible with what libsequence is compiled with.