### PR TITLE
Refactor unit tests

### DIFF
--- a/test/AlignStreamTest.cc
+++ b/test/AlignStreamTest.cc
@@ -1,14 +1,14 @@
 //! \file AlignStreamTest.cc @brief unit tests for Sequence::ClustalW and Sequence::phylipData
-#define BOOST_TEST_MODULE AlignStream
 
 #include <Sequence/Fasta.hpp>
 #include <Sequence/Clustalw.hpp>
 #include <Sequence/phylipData.hpp>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <fstream>
 #include <iostream>
 #include <unistd.h>
 
+BOOST_AUTO_TEST_SUITE(AlignStreamTest)
 const char * input_data = "data/CG15644-Z.aln";
 const char * phylip_input_data = "data/phylip_input.txt";
 
@@ -313,4 +313,5 @@ BOOST_AUTO_TEST_CASE( convert_write_read )
   unlink(outfile);
 }
 
+BOOST_AUTO_TEST_SUITE_END()
 //EOF

--- a/test/AlignmentTest.cc
+++ b/test/AlignmentTest.cc
@@ -9,16 +9,16 @@
   This module tests both
 */
 
-#define BOOST_TEST_MODULE AlignmentTest
-
 #include <Sequence/Fasta.hpp>
 #include <Sequence/Alignment.hpp>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <vector>
 #include <fstream>
 #include <iterator>
 #include <algorithm>
 #include <unistd.h>
+
+BOOST_AUTO_TEST_SUITE(AlignmentTest)
 
 BOOST_AUTO_TEST_CASE( IsAlignmentFasta )
 {
@@ -464,3 +464,4 @@ BOOST_AUTO_TEST_CASE( TrimComplementSameResults )
       BOOST_REQUIRE_EQUAL( vf2[i].second,vs2[i] );
     }
 }
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/ComparisonsTest.cc
+++ b/test/ComparisonsTest.cc
@@ -1,11 +1,11 @@
 //! \file ComparisonsTests.cc @brief Tests for Sequence/Comparisons.hpp
-#define BOOST_TEST_MODULE ComparisonsTest
 
 #include <Sequence/Comparisons.hpp>
 #include <Sequence/SeqAlphabets.hpp>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <algorithm>
 #include <iterator>
+BOOST_AUTO_TEST_SUITE(ComparisonsTest)
 
 BOOST_AUTO_TEST_CASE( notagap ) //Silly!
 {
@@ -111,3 +111,4 @@ BOOST_AUTO_TEST_CASE( tstv1 )
   BOOST_REQUIRE_THROW( Sequence::TsTv('G','R'), std::runtime_error );
   BOOST_REQUIRE_THROW( Sequence::TsTv('G','z'), std::runtime_error );
 }
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/CountingOperators.cc
+++ b/test/CountingOperators.cc
@@ -1,10 +1,10 @@
-#define BOOST_TEST_MODULE CountingOperators
-
 #include <Sequence/CountingOperators.hpp>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <algorithm>
 #include <functional>
 #include <string>
+
+BOOST_AUTO_TEST_SUITE(CountingOperatorsTest)
 
 BOOST_AUTO_TEST_CASE( test_counting_operators_map_plus )
 {
@@ -74,3 +74,4 @@ BOOST_AUTO_TEST_CASE( test_counting_operators_vector_plus )
   BOOST_REQUIRE_EQUAL( i->second,17 );
 
 }
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/FastaConstructors.cc
+++ b/test/FastaConstructors.cc
@@ -1,73 +1,82 @@
 //!\ file FastaConstructors.cc
-#define BOOST_TEST_MODULE FastaConstructors
 
 #include <Sequence/Fasta.hpp>
 #include <string>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <iostream>
 #include <functional>
 
-std::string name("seqname"),seq("AGCGTAGACAGTAGAGTGAT");
-
-BOOST_AUTO_TEST_CASE( empty )
+struct fasta_constructors_fixture
 {
-  Sequence::Fasta f;
-  BOOST_REQUIRE(f.first.empty());
-  BOOST_REQUIRE(f.second.empty());
+    std::string name, seq;
+    fasta_constructors_fixture()
+        : name{ "seqname" }, seq{ "AGCGTAGACAGTAGAGTGAT" }
+    {
+    }
+};
+
+BOOST_FIXTURE_TEST_SUITE(FastaConstructorsTest, fasta_constructors_fixture)
+
+BOOST_AUTO_TEST_CASE(empty)
+{
+    Sequence::Fasta f;
+    BOOST_REQUIRE(f.first.empty());
+    BOOST_REQUIRE(f.second.empty());
 }
 
-BOOST_AUTO_TEST_CASE( string_con )
+BOOST_AUTO_TEST_CASE(string_con)
 {
-  Sequence::Fasta f = Sequence::Fasta(name,seq);
-  BOOST_CHECK( f.first == name );
-  BOOST_CHECK( f.second == seq );
+    Sequence::Fasta f = Sequence::Fasta(name, seq);
+    BOOST_CHECK(f.first == name);
+    BOOST_CHECK(f.second == seq);
 }
 
-BOOST_AUTO_TEST_CASE( copy_con )
+BOOST_AUTO_TEST_CASE(copy_con)
 {
-  Sequence::Fasta f = Sequence::Fasta(name.c_str(),seq.c_str());
-  BOOST_CHECK( f.first == name );
-  BOOST_CHECK( f.second == seq );
-  
-  Sequence::Fasta f2(f);
-  BOOST_REQUIRE(f == f2);
+    Sequence::Fasta f = Sequence::Fasta(name.c_str(), seq.c_str());
+    BOOST_CHECK(f.first == name);
+    BOOST_CHECK(f.second == seq);
+
+    Sequence::Fasta f2(f);
+    BOOST_REQUIRE(f == f2);
 }
 
-BOOST_AUTO_TEST_CASE( move_con )
+BOOST_AUTO_TEST_CASE(move_con)
 {
-  Sequence::Fasta f = Sequence::Fasta(name.c_str(),seq.c_str());
-  BOOST_CHECK( f.first == name );
-  BOOST_CHECK( f.second == seq );
-  
-  Sequence::Fasta f2(std::move(f));
-  BOOST_CHECK( f2.first == name );
-  BOOST_CHECK( f2.second == seq );
-  BOOST_CHECK( f.length() == 0 );
-  BOOST_CHECK( f.first.empty() );
+    Sequence::Fasta f = Sequence::Fasta(name.c_str(), seq.c_str());
+    BOOST_CHECK(f.first == name);
+    BOOST_CHECK(f.second == seq);
+
+    Sequence::Fasta f2(std::move(f));
+    BOOST_CHECK(f2.first == name);
+    BOOST_CHECK(f2.second == seq);
+    BOOST_CHECK(f.length() == 0);
+    BOOST_CHECK(f.first.empty());
 }
 
-BOOST_AUTO_TEST_CASE( move_con2 )
+BOOST_AUTO_TEST_CASE(move_con2)
 //This "should" work???
 {
-  std::string a(name),b(seq);
-  Sequence::Fasta f = Sequence::Fasta(std::move(a),std::move(b));
-  BOOST_CHECK( f.first == name );
-  BOOST_CHECK( f.second == seq );
-  BOOST_CHECK( a.empty() );
-  BOOST_CHECK( b.empty() );
+    std::string a(name), b(seq);
+    Sequence::Fasta f = Sequence::Fasta(std::move(a), std::move(b));
+    BOOST_CHECK(f.first == name);
+    BOOST_CHECK(f.second == seq);
+    BOOST_CHECK(a.empty());
+    BOOST_CHECK(b.empty());
 }
 
-BOOST_AUTO_TEST_CASE( move_assign )
+BOOST_AUTO_TEST_CASE(move_assign)
 {
-  Sequence::Fasta f = Sequence::Fasta(name,seq);
-  BOOST_CHECK( f.first == name );
-  BOOST_CHECK( f.second == seq );
+    Sequence::Fasta f = Sequence::Fasta(name, seq);
+    BOOST_CHECK(f.first == name);
+    BOOST_CHECK(f.second == seq);
 
-  Sequence::Fasta f2;
-  f2 = std::move(f);
-  BOOST_CHECK( f2.first == name );
-  BOOST_CHECK( f2.second == seq );
-  BOOST_CHECK( f.length() == 0 );
-  BOOST_CHECK( f.first.empty() );
+    Sequence::Fasta f2;
+    f2 = std::move(f);
+    BOOST_CHECK(f2.first == name);
+    BOOST_CHECK(f2.second == seq);
+    BOOST_CHECK(f.length() == 0);
+    BOOST_CHECK(f.first.empty());
 }
+BOOST_AUTO_TEST_SUITE_END()
 //EOF

--- a/test/FastaExplicitIO.cc
+++ b/test/FastaExplicitIO.cc
@@ -1,12 +1,12 @@
-#define BOOST_TEST_MODULE FastaExplicitIO
 
 #include <Sequence/FastaExplicit.hpp>
 #include <fstream>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <unistd.h>
 #include <iterator>
 
 std::string name("seqname is a seq"),seq("AGCGTAGACAGTAGAGTGAT"),seq_left("AGCGTAGAC"),seq_right("AGTAGAGTGAT");
+
 
 BOOST_AUTO_TEST_CASE( ostream_test )
 {
@@ -151,4 +151,5 @@ BOOST_AUTO_TEST_CASE( exception_test )
   unlink(filename);
 }
 
+BOOST_AUTO_TEST_SUITE_END()
 //EOF

--- a/test/FastaIO.cc
+++ b/test/FastaIO.cc
@@ -1,159 +1,162 @@
-#define BOOST_TEST_MODULE FastaIO
-
 #include <Sequence/Fasta.hpp>
 #include <fstream>
 #include <iostream>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <unistd.h>
 #include <iterator>
 
-std::string name("seqname is a seq"),seq("AGCGTAGACAGTAGAGTGAT"),seq_left("AGCGTAGAC"),seq_right("AGTAGAGTGAT");
-
-BOOST_AUTO_TEST_CASE( ostream_test )
+struct fasta_io_fixture
 {
-  const char * filename = "fasta_ostream_test_out.fasta";
-  Sequence::Fasta f(name,seq),f2;
-  std::ofstream o(filename);
-  o << f << std::endl;
-  o.close();
-  std::ifstream in(filename);
-  in >> f2 >> std::ws;
-  BOOST_REQUIRE_EQUAL(f,f2);
-  unlink(filename);
+    std::string name, seq, seq_left, seq_right;
+    fasta_io_fixture()
+        : name{ "seqname is a seq" }, seq{ "AGCGTAGACAGTAGAGTGAT" },
+          seq_left{ "AGCGTAGAC" }, seq_right{ "AGTAGAGTGAT" }
+    {
+    }
+};
+
+BOOST_FIXTURE_TEST_SUITE(FastaIOTest,fasta_io_fixture)
+
+BOOST_AUTO_TEST_CASE(ostream_test)
+{
+    const char* filename = "fasta_ostream_test_out.fasta";
+    Sequence::Fasta f(name, seq), f2;
+    std::ofstream o(filename);
+    o << f << std::endl;
+    o.close();
+    std::ifstream in(filename);
+    in >> f2 >> std::ws;
+    BOOST_REQUIRE_EQUAL(f, f2);
+    unlink(filename);
 }
 
-BOOST_AUTO_TEST_CASE( ostream_test_3recs )
+BOOST_AUTO_TEST_CASE(ostream_test_3recs)
 {
-  const char * filename = "fasta_ostream_test_out.fasta";
-  Sequence::Fasta f(name,seq),f2;
-  std::ofstream o(filename);
-  o << f << '\n'
-    << f << '\n'
-    << f << '\n';
-  o.close();
-  std::ifstream in(filename);
-  unsigned count = 0;
-  while(! in.eof() )
-    {
-      in >> f2 >> std::ws;
-      BOOST_REQUIRE_EQUAL(f.first,f2.first);
-      BOOST_REQUIRE_EQUAL(f.second,f2.second);
-      ++count;
-    }
-  BOOST_REQUIRE_EQUAL( count, 3 );
-  //in >> f2 >> std::ws;
-  
-  unlink(filename);
+    const char* filename = "fasta_ostream_test_out.fasta";
+    Sequence::Fasta f(name, seq), f2;
+    std::ofstream o(filename);
+    o << f << '\n' << f << '\n' << f << '\n';
+    o.close();
+    std::ifstream in(filename);
+    unsigned count = 0;
+    while (!in.eof())
+        {
+            in >> f2 >> std::ws;
+            BOOST_REQUIRE_EQUAL(f.first, f2.first);
+            BOOST_REQUIRE_EQUAL(f.second, f2.second);
+            ++count;
+        }
+    BOOST_REQUIRE_EQUAL(count, 3);
+    //in >> f2 >> std::ws;
+
+    unlink(filename);
 }
 
 //No newline @ end of data
-BOOST_AUTO_TEST_CASE( ostream_test_no_newline_end_of_file )
+BOOST_AUTO_TEST_CASE(ostream_test_no_newline_end_of_file)
 {
-  const char * filename = "fasta_ostream_test_out.fasta";
-  Sequence::Fasta f(name,seq),f2;
-  std::ofstream o(filename);
-  o << f << '\n'
-    << f << '\n'
-    << f;
-  o.close();
-  std::ifstream in(filename);
-  unsigned count = 0;
-  while(! in.eof() )
-    {
-      in >> f2 >> std::ws;
-      BOOST_REQUIRE_EQUAL(f.first,f2.first);
-      BOOST_REQUIRE_EQUAL(f.second,f2.second);
-      ++count;
-    }
-  BOOST_REQUIRE_EQUAL( count, 3 );
-  unlink(filename);
+    const char* filename = "fasta_ostream_test_out.fasta";
+    Sequence::Fasta f(name, seq), f2;
+    std::ofstream o(filename);
+    o << f << '\n' << f << '\n' << f;
+    o.close();
+    std::ifstream in(filename);
+    unsigned count = 0;
+    while (!in.eof())
+        {
+            in >> f2 >> std::ws;
+            BOOST_REQUIRE_EQUAL(f.first, f2.first);
+            BOOST_REQUIRE_EQUAL(f.second, f2.second);
+            ++count;
+        }
+    BOOST_REQUIRE_EQUAL(count, 3);
+    unlink(filename);
 }
 
-BOOST_AUTO_TEST_CASE( ostream_test_newline_within_seq )
+BOOST_AUTO_TEST_CASE(ostream_test_newline_within_seq)
 {
-  const char * filename = "fasta_ostream_test_out.fasta";
-  Sequence::Fasta f(name,seq),f2;
-  std::ofstream o(filename);
-  for ( unsigned i = 0 ; i < 3 ; ++i )
-    {
-      o << '>' << name << '\n'
-	<< seq_left << '\n'
-	<< seq_right << '\n';
-    }
-  o.close();
-  std::ifstream in(filename);
-  unsigned count = 0;
-  while(! in.eof() )
-    {
-      in >> f2 >> std::ws;
-      BOOST_REQUIRE_EQUAL(f.first,f2.first);
-      BOOST_REQUIRE_EQUAL(f.second,f2.second);
-      ++count;
-    }
-  BOOST_REQUIRE_EQUAL( count, 3 );
-  unlink(filename);
+    const char* filename = "fasta_ostream_test_out.fasta";
+    Sequence::Fasta f(name, seq), f2;
+    std::ofstream o(filename);
+    for (unsigned i = 0; i < 3; ++i)
+        {
+            o << '>' << name << '\n' << seq_left << '\n' << seq_right << '\n';
+        }
+    o.close();
+    std::ifstream in(filename);
+    unsigned count = 0;
+    while (!in.eof())
+        {
+            in >> f2 >> std::ws;
+            BOOST_REQUIRE_EQUAL(f.first, f2.first);
+            BOOST_REQUIRE_EQUAL(f.second, f2.second);
+            ++count;
+        }
+    BOOST_REQUIRE_EQUAL(count, 3);
+    unlink(filename);
 }
 
-BOOST_AUTO_TEST_CASE( ostream_test_really_bad_input )
+BOOST_AUTO_TEST_CASE(ostream_test_really_bad_input)
 {
-  const char * filename = "fasta_ostream_test_out.fasta";
-  Sequence::Fasta f(name,seq),f2;
-  std::ofstream o(filename);
-  for ( unsigned i = 0 ; i < 3 ; ++i )
-    {
-      o << '>' << name << '\n'
-	<< seq_left << "\n\n\n\n\n" //Bad bad bad
-	<< seq_right << '\n';
-    }
-  o.close();
-  std::ifstream in(filename);
-  unsigned count = 0;
-  while(! in.eof() )
-    {
-      in >> f2 >> std::ws;
-      BOOST_REQUIRE_EQUAL(f.first,f2.first);
-      BOOST_REQUIRE_EQUAL(f.second,f2.second);
-      ++count;
-    }
-  BOOST_REQUIRE_EQUAL( count, 3 );
-  unlink(filename);
+    const char* filename = "fasta_ostream_test_out.fasta";
+    Sequence::Fasta f(name, seq), f2;
+    std::ofstream o(filename);
+    for (unsigned i = 0; i < 3; ++i)
+        {
+            o << '>' << name << '\n'
+              << seq_left << "\n\n\n\n\n" //Bad bad bad
+              << seq_right << '\n';
+        }
+    o.close();
+    std::ifstream in(filename);
+    unsigned count = 0;
+    while (!in.eof())
+        {
+            in >> f2 >> std::ws;
+            BOOST_REQUIRE_EQUAL(f.first, f2.first);
+            BOOST_REQUIRE_EQUAL(f.second, f2.second);
+            ++count;
+        }
+    BOOST_REQUIRE_EQUAL(count, 3);
+    unlink(filename);
 }
 
-BOOST_AUTO_TEST_CASE( ostream_test_really_bad_input_istream_iterator )
+BOOST_AUTO_TEST_CASE(ostream_test_really_bad_input_istream_iterator)
 {
-  const char * filename = "fasta_ostream_test_out.fasta";
-  Sequence::Fasta f(name,seq),f2;
-  std::ofstream o(filename);
-  for ( unsigned i = 0 ; i < 3 ; ++i )
-    {
-      o << '>' << name << '\n'
-	<< seq_left << "\n\n\n\n\n" //Bad bad bad
-	<< seq_right << '\n';
-    }
-  o.close();
-  std::ifstream in(filename);
-  unsigned count = 0;
-  std::istream_iterator<Sequence::Fasta> i(in);
-  for( ; i != std::istream_iterator<Sequence::Fasta>() ; ++i )
-    {
-      ++count;  
-    }
-  BOOST_REQUIRE_EQUAL( count, 3 );
-  unlink(filename);
+    const char* filename = "fasta_ostream_test_out.fasta";
+    Sequence::Fasta f(name, seq), f2;
+    std::ofstream o(filename);
+    for (unsigned i = 0; i < 3; ++i)
+        {
+            o << '>' << name << '\n'
+              << seq_left << "\n\n\n\n\n" //Bad bad bad
+              << seq_right << '\n';
+        }
+    o.close();
+    std::ifstream in(filename);
+    unsigned count = 0;
+    std::istream_iterator<Sequence::Fasta> i(in);
+    for (; i != std::istream_iterator<Sequence::Fasta>(); ++i)
+        {
+            ++count;
+        }
+    BOOST_REQUIRE_EQUAL(count, 3);
+    unlink(filename);
 }
 
-BOOST_AUTO_TEST_CASE( exception_test )
+BOOST_AUTO_TEST_CASE(exception_test)
 {
-  const char * filename = "fasta_ostream_test_out.fasta";
-  std::ofstream out(filename);
-  //Write a badly-formatted FASTA record (we forgot the >)
-  out << name << '\n' << seq;
-  out.close();
+    const char* filename = "fasta_ostream_test_out.fasta";
+    std::ofstream out(filename);
+    //Write a badly-formatted FASTA record (we forgot the >)
+    out << name << '\n' << seq;
+    out.close();
 
-  std::ifstream in(filename);
-  Sequence::Fasta f;
-  BOOST_CHECK_THROW( in >> f >> std::ws, std::runtime_error );
-  unlink(filename);
+    std::ifstream in(filename);
+    Sequence::Fasta f;
+    BOOST_CHECK_THROW(in >> f >> std::ws, std::runtime_error);
+    unlink(filename);
 }
 
+BOOST_AUTO_TEST_SUITE_END()
 //EOF

--- a/test/FastaOperations.cc
+++ b/test/FastaOperations.cc
@@ -1,12 +1,22 @@
 //\file FastaOperations.cc
-#define BOOST_TEST_MODULE FastaOperations
 
 #include <Sequence/Fasta.hpp>
 #include <string>
 #include <iostream>
 #include <algorithm>
 #include <numeric>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
+
+struct fasta_operations_fixture
+{
+    std::string name, seq;
+    fasta_operations_fixture()
+        : name{ "seqname" }, seq{ "AGCGTAGACAGTAGAGTGAT" }
+    {
+    }
+};
+
+BOOST_FIXTURE_TEST_SUITE(FastaOperationsTest, fasta_operations_fixture)
 
 //A generic revcom routine written for this test
 std::string rcom( const std::string & s )
@@ -100,4 +110,5 @@ BOOST_AUTO_TEST_CASE( cpp11access_1 )
   BOOST_REQUIRE_EQUAL(f3.second,"AAA");
 }
 
+BOOST_AUTO_TEST_SUITE_END()
 //EOF

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,27 +1,6 @@
 if BUNIT_TEST_PRESENT
 
-check_PROGRAMS=FastaConstructors FastaIO FastaOperations \
-	AlignStreamTest \
-	testSimDataIO \
-	CountingOperators \
-	PolyTableConversions \
-	PolyTableTweaking \
-	PolyTableBadBehavior \
-	PolySitesIO \
-	SimpleSNPIO \
-	PolySIMtest \
-	PolySNPtest \
-	ComparisonsTest \
-	AlignmentTest \
-	fastqIO \
-	fastqConstructors \
-	SeqConversions \
-	RedundancyCom95test \
-	alphabets \
-	polySiteVectorTest \
-	PolyTableSliceTest \
-	stateCounterTest \
-	VariantMatrixTest
+check_PROGRAMS=libseq_unit_tests
 
 TESTS=$(check_PROGRAMS)
 
@@ -43,50 +22,30 @@ AM_LIBS=-lsequence
 
 LIBS+=$(AM_LIBS)
 
-FastaConstructors_SOURCES=FastaConstructors.cc
-FastaIO_SOURCES=FastaIO.cc
-FastaOperations_SOURCES=FastaOperations.cc
-
-AlignStreamTest_SOURCES=AlignStreamTest.cc
-
-testSimDataIO_SOURCES=testSimDataIO.cc
-
-CountingOperators_SOURCES=CountingOperators.cc
-
-PolyTableConversions_SOURCES=PolyTableConversions.cc
-
-PolyTableTweaking_SOURCES=PolyTableTweaking.cc
-
-PolyTableBadBehavior_SOURCES=PolyTableBadBehavior.cc
-
-PolySitesIO_SOURCES=PolySitesIO.cc
-
-SimpleSNPIO_SOURCES=SimpleSNPIO.cc
-
-PolySIMtest_SOURCES=PolySIMtest.cc
-
-PolySNPtest_SOURCES=PolySNPtest.cc
-
-ComparisonsTest_SOURCES=ComparisonsTest.cc
-
-AlignmentTest_SOURCES=AlignmentTest.cc
-
-fastqIO_SOURCES=fastqIO.cc
-
-fastqConstructors_SOURCES=fastqConstructors.cc
-
-SeqConversions_SOURCES=SeqConversions.cc
-
-RedundancyCom95test_SOURCES=RedundancyCom95test.cc
-
-alphabets_SOURCES=alphabets.cc
-
-polySiteVectorTest_SOURCES=polySiteVectorTest.cc
-
-PolyTableSliceTest_SOURCES=PolyTableSliceTest.cc
-
-stateCounterTest_SOURCES=stateCounterTest.cc
-
-VariantMatrixTest_SOURCES=VariantMatrixTest.cc
+libseq_unit_tests_SOURCES=libseq_unit_tests.cc \
+FastaConstructors.cc \
+FastaIO.cc \
+FastaOperations.cc \
+AlignStreamTest.cc \
+testSimDataIO.cc \
+CountingOperators.cc \
+PolyTableConversions.cc \
+PolyTableTweaking.cc \
+PolyTableBadBehavior.cc \
+PolySitesIO.cc \
+SimpleSNPIO.cc \
+PolySIMtest.cc \
+PolySNPtest.cc \
+ComparisonsTest.cc \
+AlignmentTest.cc \
+fastqIO.cc \
+fastqConstructors.cc \
+SeqConversions.cc \
+RedundancyCom95test.cc \
+alphabets.cc \
+polySiteVectorTest.cc \
+PolyTableSliceTest.cc \
+stateCounterTest.cc \
+VariantMatrixTest.cc
 
 endif #if BUNIT_TEST_PRESENT

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -87,30 +87,7 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 build_triplet = @build@
 host_triplet = @host@
-@BUNIT_TEST_PRESENT_TRUE@check_PROGRAMS = FastaConstructors$(EXEEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	FastaIO$(EXEEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	FastaOperations$(EXEEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	AlignStreamTest$(EXEEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	testSimDataIO$(EXEEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	CountingOperators$(EXEEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	PolyTableConversions$(EXEEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	PolyTableTweaking$(EXEEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	PolyTableBadBehavior$(EXEEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	PolySitesIO$(EXEEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	SimpleSNPIO$(EXEEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	PolySIMtest$(EXEEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	PolySNPtest$(EXEEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	ComparisonsTest$(EXEEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	AlignmentTest$(EXEEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	fastqIO$(EXEEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	fastqConstructors$(EXEEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	SeqConversions$(EXEEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	RedundancyCom95test$(EXEEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	alphabets$(EXEEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	polySiteVectorTest$(EXEEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	PolyTableSliceTest$(EXEEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	stateCounterTest$(EXEEXT) \
-@BUNIT_TEST_PRESENT_TRUE@	VariantMatrixTest$(EXEEXT)
+@BUNIT_TEST_PRESENT_TRUE@check_PROGRAMS = libseq_unit_tests$(EXEEXT)
 
 #if DEBUG
 #AM_CXXFLAGS+=-g
@@ -137,127 +114,48 @@ mkinstalldirs = $(install_sh) -d
 CONFIG_HEADER = $(top_builddir)/config.h
 CONFIG_CLEAN_FILES =
 CONFIG_CLEAN_VPATH_FILES =
-am__AlignStreamTest_SOURCES_DIST = AlignStreamTest.cc
-@BUNIT_TEST_PRESENT_TRUE@am_AlignStreamTest_OBJECTS =  \
-@BUNIT_TEST_PRESENT_TRUE@	AlignStreamTest.$(OBJEXT)
-AlignStreamTest_OBJECTS = $(am_AlignStreamTest_OBJECTS)
-AlignStreamTest_LDADD = $(LDADD)
+am__libseq_unit_tests_SOURCES_DIST = libseq_unit_tests.cc \
+	FastaConstructors.cc FastaIO.cc FastaOperations.cc \
+	AlignStreamTest.cc testSimDataIO.cc CountingOperators.cc \
+	PolyTableConversions.cc PolyTableTweaking.cc \
+	PolyTableBadBehavior.cc PolySitesIO.cc SimpleSNPIO.cc \
+	PolySIMtest.cc PolySNPtest.cc ComparisonsTest.cc \
+	AlignmentTest.cc fastqIO.cc fastqConstructors.cc \
+	SeqConversions.cc RedundancyCom95test.cc alphabets.cc \
+	polySiteVectorTest.cc PolyTableSliceTest.cc \
+	stateCounterTest.cc VariantMatrixTest.cc
+@BUNIT_TEST_PRESENT_TRUE@am_libseq_unit_tests_OBJECTS =  \
+@BUNIT_TEST_PRESENT_TRUE@	libseq_unit_tests.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	FastaConstructors.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	FastaIO.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	FastaOperations.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	AlignStreamTest.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	testSimDataIO.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	CountingOperators.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	PolyTableConversions.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	PolyTableTweaking.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	PolyTableBadBehavior.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	PolySitesIO.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	SimpleSNPIO.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	PolySIMtest.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	PolySNPtest.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	ComparisonsTest.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	AlignmentTest.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	fastqIO.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	fastqConstructors.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	SeqConversions.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	RedundancyCom95test.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	alphabets.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	polySiteVectorTest.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	PolyTableSliceTest.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	stateCounterTest.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	VariantMatrixTest.$(OBJEXT)
+libseq_unit_tests_OBJECTS = $(am_libseq_unit_tests_OBJECTS)
+libseq_unit_tests_LDADD = $(LDADD)
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
 am__v_lt_0 = --silent
 am__v_lt_1 = 
-am__AlignmentTest_SOURCES_DIST = AlignmentTest.cc
-@BUNIT_TEST_PRESENT_TRUE@am_AlignmentTest_OBJECTS =  \
-@BUNIT_TEST_PRESENT_TRUE@	AlignmentTest.$(OBJEXT)
-AlignmentTest_OBJECTS = $(am_AlignmentTest_OBJECTS)
-AlignmentTest_LDADD = $(LDADD)
-am__ComparisonsTest_SOURCES_DIST = ComparisonsTest.cc
-@BUNIT_TEST_PRESENT_TRUE@am_ComparisonsTest_OBJECTS =  \
-@BUNIT_TEST_PRESENT_TRUE@	ComparisonsTest.$(OBJEXT)
-ComparisonsTest_OBJECTS = $(am_ComparisonsTest_OBJECTS)
-ComparisonsTest_LDADD = $(LDADD)
-am__CountingOperators_SOURCES_DIST = CountingOperators.cc
-@BUNIT_TEST_PRESENT_TRUE@am_CountingOperators_OBJECTS =  \
-@BUNIT_TEST_PRESENT_TRUE@	CountingOperators.$(OBJEXT)
-CountingOperators_OBJECTS = $(am_CountingOperators_OBJECTS)
-CountingOperators_LDADD = $(LDADD)
-am__FastaConstructors_SOURCES_DIST = FastaConstructors.cc
-@BUNIT_TEST_PRESENT_TRUE@am_FastaConstructors_OBJECTS =  \
-@BUNIT_TEST_PRESENT_TRUE@	FastaConstructors.$(OBJEXT)
-FastaConstructors_OBJECTS = $(am_FastaConstructors_OBJECTS)
-FastaConstructors_LDADD = $(LDADD)
-am__FastaIO_SOURCES_DIST = FastaIO.cc
-@BUNIT_TEST_PRESENT_TRUE@am_FastaIO_OBJECTS = FastaIO.$(OBJEXT)
-FastaIO_OBJECTS = $(am_FastaIO_OBJECTS)
-FastaIO_LDADD = $(LDADD)
-am__FastaOperations_SOURCES_DIST = FastaOperations.cc
-@BUNIT_TEST_PRESENT_TRUE@am_FastaOperations_OBJECTS =  \
-@BUNIT_TEST_PRESENT_TRUE@	FastaOperations.$(OBJEXT)
-FastaOperations_OBJECTS = $(am_FastaOperations_OBJECTS)
-FastaOperations_LDADD = $(LDADD)
-am__PolySIMtest_SOURCES_DIST = PolySIMtest.cc
-@BUNIT_TEST_PRESENT_TRUE@am_PolySIMtest_OBJECTS =  \
-@BUNIT_TEST_PRESENT_TRUE@	PolySIMtest.$(OBJEXT)
-PolySIMtest_OBJECTS = $(am_PolySIMtest_OBJECTS)
-PolySIMtest_LDADD = $(LDADD)
-am__PolySNPtest_SOURCES_DIST = PolySNPtest.cc
-@BUNIT_TEST_PRESENT_TRUE@am_PolySNPtest_OBJECTS =  \
-@BUNIT_TEST_PRESENT_TRUE@	PolySNPtest.$(OBJEXT)
-PolySNPtest_OBJECTS = $(am_PolySNPtest_OBJECTS)
-PolySNPtest_LDADD = $(LDADD)
-am__PolySitesIO_SOURCES_DIST = PolySitesIO.cc
-@BUNIT_TEST_PRESENT_TRUE@am_PolySitesIO_OBJECTS =  \
-@BUNIT_TEST_PRESENT_TRUE@	PolySitesIO.$(OBJEXT)
-PolySitesIO_OBJECTS = $(am_PolySitesIO_OBJECTS)
-PolySitesIO_LDADD = $(LDADD)
-am__PolyTableBadBehavior_SOURCES_DIST = PolyTableBadBehavior.cc
-@BUNIT_TEST_PRESENT_TRUE@am_PolyTableBadBehavior_OBJECTS =  \
-@BUNIT_TEST_PRESENT_TRUE@	PolyTableBadBehavior.$(OBJEXT)
-PolyTableBadBehavior_OBJECTS = $(am_PolyTableBadBehavior_OBJECTS)
-PolyTableBadBehavior_LDADD = $(LDADD)
-am__PolyTableConversions_SOURCES_DIST = PolyTableConversions.cc
-@BUNIT_TEST_PRESENT_TRUE@am_PolyTableConversions_OBJECTS =  \
-@BUNIT_TEST_PRESENT_TRUE@	PolyTableConversions.$(OBJEXT)
-PolyTableConversions_OBJECTS = $(am_PolyTableConversions_OBJECTS)
-PolyTableConversions_LDADD = $(LDADD)
-am__PolyTableSliceTest_SOURCES_DIST = PolyTableSliceTest.cc
-@BUNIT_TEST_PRESENT_TRUE@am_PolyTableSliceTest_OBJECTS =  \
-@BUNIT_TEST_PRESENT_TRUE@	PolyTableSliceTest.$(OBJEXT)
-PolyTableSliceTest_OBJECTS = $(am_PolyTableSliceTest_OBJECTS)
-PolyTableSliceTest_LDADD = $(LDADD)
-am__PolyTableTweaking_SOURCES_DIST = PolyTableTweaking.cc
-@BUNIT_TEST_PRESENT_TRUE@am_PolyTableTweaking_OBJECTS =  \
-@BUNIT_TEST_PRESENT_TRUE@	PolyTableTweaking.$(OBJEXT)
-PolyTableTweaking_OBJECTS = $(am_PolyTableTweaking_OBJECTS)
-PolyTableTweaking_LDADD = $(LDADD)
-am__RedundancyCom95test_SOURCES_DIST = RedundancyCom95test.cc
-@BUNIT_TEST_PRESENT_TRUE@am_RedundancyCom95test_OBJECTS =  \
-@BUNIT_TEST_PRESENT_TRUE@	RedundancyCom95test.$(OBJEXT)
-RedundancyCom95test_OBJECTS = $(am_RedundancyCom95test_OBJECTS)
-RedundancyCom95test_LDADD = $(LDADD)
-am__SeqConversions_SOURCES_DIST = SeqConversions.cc
-@BUNIT_TEST_PRESENT_TRUE@am_SeqConversions_OBJECTS =  \
-@BUNIT_TEST_PRESENT_TRUE@	SeqConversions.$(OBJEXT)
-SeqConversions_OBJECTS = $(am_SeqConversions_OBJECTS)
-SeqConversions_LDADD = $(LDADD)
-am__SimpleSNPIO_SOURCES_DIST = SimpleSNPIO.cc
-@BUNIT_TEST_PRESENT_TRUE@am_SimpleSNPIO_OBJECTS =  \
-@BUNIT_TEST_PRESENT_TRUE@	SimpleSNPIO.$(OBJEXT)
-SimpleSNPIO_OBJECTS = $(am_SimpleSNPIO_OBJECTS)
-SimpleSNPIO_LDADD = $(LDADD)
-am__VariantMatrixTest_SOURCES_DIST = VariantMatrixTest.cc
-@BUNIT_TEST_PRESENT_TRUE@am_VariantMatrixTest_OBJECTS =  \
-@BUNIT_TEST_PRESENT_TRUE@	VariantMatrixTest.$(OBJEXT)
-VariantMatrixTest_OBJECTS = $(am_VariantMatrixTest_OBJECTS)
-VariantMatrixTest_LDADD = $(LDADD)
-am__alphabets_SOURCES_DIST = alphabets.cc
-@BUNIT_TEST_PRESENT_TRUE@am_alphabets_OBJECTS = alphabets.$(OBJEXT)
-alphabets_OBJECTS = $(am_alphabets_OBJECTS)
-alphabets_LDADD = $(LDADD)
-am__fastqConstructors_SOURCES_DIST = fastqConstructors.cc
-@BUNIT_TEST_PRESENT_TRUE@am_fastqConstructors_OBJECTS =  \
-@BUNIT_TEST_PRESENT_TRUE@	fastqConstructors.$(OBJEXT)
-fastqConstructors_OBJECTS = $(am_fastqConstructors_OBJECTS)
-fastqConstructors_LDADD = $(LDADD)
-am__fastqIO_SOURCES_DIST = fastqIO.cc
-@BUNIT_TEST_PRESENT_TRUE@am_fastqIO_OBJECTS = fastqIO.$(OBJEXT)
-fastqIO_OBJECTS = $(am_fastqIO_OBJECTS)
-fastqIO_LDADD = $(LDADD)
-am__polySiteVectorTest_SOURCES_DIST = polySiteVectorTest.cc
-@BUNIT_TEST_PRESENT_TRUE@am_polySiteVectorTest_OBJECTS =  \
-@BUNIT_TEST_PRESENT_TRUE@	polySiteVectorTest.$(OBJEXT)
-polySiteVectorTest_OBJECTS = $(am_polySiteVectorTest_OBJECTS)
-polySiteVectorTest_LDADD = $(LDADD)
-am__stateCounterTest_SOURCES_DIST = stateCounterTest.cc
-@BUNIT_TEST_PRESENT_TRUE@am_stateCounterTest_OBJECTS =  \
-@BUNIT_TEST_PRESENT_TRUE@	stateCounterTest.$(OBJEXT)
-stateCounterTest_OBJECTS = $(am_stateCounterTest_OBJECTS)
-stateCounterTest_LDADD = $(LDADD)
-am__testSimDataIO_SOURCES_DIST = testSimDataIO.cc
-@BUNIT_TEST_PRESENT_TRUE@am_testSimDataIO_OBJECTS =  \
-@BUNIT_TEST_PRESENT_TRUE@	testSimDataIO.$(OBJEXT)
-testSimDataIO_OBJECTS = $(am_testSimDataIO_OBJECTS)
-testSimDataIO_LDADD = $(LDADD)
 AM_V_P = $(am__v_P_@AM_V@)
 am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
 am__v_P_0 = false
@@ -292,43 +190,8 @@ AM_V_CXXLD = $(am__v_CXXLD_@AM_V@)
 am__v_CXXLD_ = $(am__v_CXXLD_@AM_DEFAULT_V@)
 am__v_CXXLD_0 = @echo "  CXXLD   " $@;
 am__v_CXXLD_1 = 
-SOURCES = $(AlignStreamTest_SOURCES) $(AlignmentTest_SOURCES) \
-	$(ComparisonsTest_SOURCES) $(CountingOperators_SOURCES) \
-	$(FastaConstructors_SOURCES) $(FastaIO_SOURCES) \
-	$(FastaOperations_SOURCES) $(PolySIMtest_SOURCES) \
-	$(PolySNPtest_SOURCES) $(PolySitesIO_SOURCES) \
-	$(PolyTableBadBehavior_SOURCES) \
-	$(PolyTableConversions_SOURCES) $(PolyTableSliceTest_SOURCES) \
-	$(PolyTableTweaking_SOURCES) $(RedundancyCom95test_SOURCES) \
-	$(SeqConversions_SOURCES) $(SimpleSNPIO_SOURCES) \
-	$(VariantMatrixTest_SOURCES) $(alphabets_SOURCES) \
-	$(fastqConstructors_SOURCES) $(fastqIO_SOURCES) \
-	$(polySiteVectorTest_SOURCES) $(stateCounterTest_SOURCES) \
-	$(testSimDataIO_SOURCES)
-DIST_SOURCES = $(am__AlignStreamTest_SOURCES_DIST) \
-	$(am__AlignmentTest_SOURCES_DIST) \
-	$(am__ComparisonsTest_SOURCES_DIST) \
-	$(am__CountingOperators_SOURCES_DIST) \
-	$(am__FastaConstructors_SOURCES_DIST) \
-	$(am__FastaIO_SOURCES_DIST) \
-	$(am__FastaOperations_SOURCES_DIST) \
-	$(am__PolySIMtest_SOURCES_DIST) \
-	$(am__PolySNPtest_SOURCES_DIST) \
-	$(am__PolySitesIO_SOURCES_DIST) \
-	$(am__PolyTableBadBehavior_SOURCES_DIST) \
-	$(am__PolyTableConversions_SOURCES_DIST) \
-	$(am__PolyTableSliceTest_SOURCES_DIST) \
-	$(am__PolyTableTweaking_SOURCES_DIST) \
-	$(am__RedundancyCom95test_SOURCES_DIST) \
-	$(am__SeqConversions_SOURCES_DIST) \
-	$(am__SimpleSNPIO_SOURCES_DIST) \
-	$(am__VariantMatrixTest_SOURCES_DIST) \
-	$(am__alphabets_SOURCES_DIST) \
-	$(am__fastqConstructors_SOURCES_DIST) \
-	$(am__fastqIO_SOURCES_DIST) \
-	$(am__polySiteVectorTest_SOURCES_DIST) \
-	$(am__stateCounterTest_SOURCES_DIST) \
-	$(am__testSimDataIO_SOURCES_DIST)
+SOURCES = $(libseq_unit_tests_SOURCES)
+DIST_SOURCES = $(am__libseq_unit_tests_SOURCES_DIST)
 am__can_run_installinfo = \
   case $$AM_UPDATE_INFO_DIR in \
     n|no|NO) false;; \
@@ -686,30 +549,32 @@ top_srcdir = @top_srcdir@
 @BUNIT_TEST_PRESENT_TRUE@AM_CXXFLAGS = -g
 @BUNIT_TEST_PRESENT_TRUE@AM_LDFLAGS = -L../src/.libs -static
 @BUNIT_TEST_PRESENT_TRUE@AM_LIBS = -lsequence
-@BUNIT_TEST_PRESENT_TRUE@FastaConstructors_SOURCES = FastaConstructors.cc
-@BUNIT_TEST_PRESENT_TRUE@FastaIO_SOURCES = FastaIO.cc
-@BUNIT_TEST_PRESENT_TRUE@FastaOperations_SOURCES = FastaOperations.cc
-@BUNIT_TEST_PRESENT_TRUE@AlignStreamTest_SOURCES = AlignStreamTest.cc
-@BUNIT_TEST_PRESENT_TRUE@testSimDataIO_SOURCES = testSimDataIO.cc
-@BUNIT_TEST_PRESENT_TRUE@CountingOperators_SOURCES = CountingOperators.cc
-@BUNIT_TEST_PRESENT_TRUE@PolyTableConversions_SOURCES = PolyTableConversions.cc
-@BUNIT_TEST_PRESENT_TRUE@PolyTableTweaking_SOURCES = PolyTableTweaking.cc
-@BUNIT_TEST_PRESENT_TRUE@PolyTableBadBehavior_SOURCES = PolyTableBadBehavior.cc
-@BUNIT_TEST_PRESENT_TRUE@PolySitesIO_SOURCES = PolySitesIO.cc
-@BUNIT_TEST_PRESENT_TRUE@SimpleSNPIO_SOURCES = SimpleSNPIO.cc
-@BUNIT_TEST_PRESENT_TRUE@PolySIMtest_SOURCES = PolySIMtest.cc
-@BUNIT_TEST_PRESENT_TRUE@PolySNPtest_SOURCES = PolySNPtest.cc
-@BUNIT_TEST_PRESENT_TRUE@ComparisonsTest_SOURCES = ComparisonsTest.cc
-@BUNIT_TEST_PRESENT_TRUE@AlignmentTest_SOURCES = AlignmentTest.cc
-@BUNIT_TEST_PRESENT_TRUE@fastqIO_SOURCES = fastqIO.cc
-@BUNIT_TEST_PRESENT_TRUE@fastqConstructors_SOURCES = fastqConstructors.cc
-@BUNIT_TEST_PRESENT_TRUE@SeqConversions_SOURCES = SeqConversions.cc
-@BUNIT_TEST_PRESENT_TRUE@RedundancyCom95test_SOURCES = RedundancyCom95test.cc
-@BUNIT_TEST_PRESENT_TRUE@alphabets_SOURCES = alphabets.cc
-@BUNIT_TEST_PRESENT_TRUE@polySiteVectorTest_SOURCES = polySiteVectorTest.cc
-@BUNIT_TEST_PRESENT_TRUE@PolyTableSliceTest_SOURCES = PolyTableSliceTest.cc
-@BUNIT_TEST_PRESENT_TRUE@stateCounterTest_SOURCES = stateCounterTest.cc
-@BUNIT_TEST_PRESENT_TRUE@VariantMatrixTest_SOURCES = VariantMatrixTest.cc
+@BUNIT_TEST_PRESENT_TRUE@libseq_unit_tests_SOURCES = libseq_unit_tests.cc \
+@BUNIT_TEST_PRESENT_TRUE@FastaConstructors.cc \
+@BUNIT_TEST_PRESENT_TRUE@FastaIO.cc \
+@BUNIT_TEST_PRESENT_TRUE@FastaOperations.cc \
+@BUNIT_TEST_PRESENT_TRUE@AlignStreamTest.cc \
+@BUNIT_TEST_PRESENT_TRUE@testSimDataIO.cc \
+@BUNIT_TEST_PRESENT_TRUE@CountingOperators.cc \
+@BUNIT_TEST_PRESENT_TRUE@PolyTableConversions.cc \
+@BUNIT_TEST_PRESENT_TRUE@PolyTableTweaking.cc \
+@BUNIT_TEST_PRESENT_TRUE@PolyTableBadBehavior.cc \
+@BUNIT_TEST_PRESENT_TRUE@PolySitesIO.cc \
+@BUNIT_TEST_PRESENT_TRUE@SimpleSNPIO.cc \
+@BUNIT_TEST_PRESENT_TRUE@PolySIMtest.cc \
+@BUNIT_TEST_PRESENT_TRUE@PolySNPtest.cc \
+@BUNIT_TEST_PRESENT_TRUE@ComparisonsTest.cc \
+@BUNIT_TEST_PRESENT_TRUE@AlignmentTest.cc \
+@BUNIT_TEST_PRESENT_TRUE@fastqIO.cc \
+@BUNIT_TEST_PRESENT_TRUE@fastqConstructors.cc \
+@BUNIT_TEST_PRESENT_TRUE@SeqConversions.cc \
+@BUNIT_TEST_PRESENT_TRUE@RedundancyCom95test.cc \
+@BUNIT_TEST_PRESENT_TRUE@alphabets.cc \
+@BUNIT_TEST_PRESENT_TRUE@polySiteVectorTest.cc \
+@BUNIT_TEST_PRESENT_TRUE@PolyTableSliceTest.cc \
+@BUNIT_TEST_PRESENT_TRUE@stateCounterTest.cc \
+@BUNIT_TEST_PRESENT_TRUE@VariantMatrixTest.cc
+
 all: all-am
 
 .SUFFIXES:
@@ -753,101 +618,9 @@ clean-checkPROGRAMS:
 	echo " rm -f" $$list; \
 	rm -f $$list
 
-AlignStreamTest$(EXEEXT): $(AlignStreamTest_OBJECTS) $(AlignStreamTest_DEPENDENCIES) $(EXTRA_AlignStreamTest_DEPENDENCIES) 
-	@rm -f AlignStreamTest$(EXEEXT)
-	$(AM_V_CXXLD)$(CXXLINK) $(AlignStreamTest_OBJECTS) $(AlignStreamTest_LDADD) $(LIBS)
-
-AlignmentTest$(EXEEXT): $(AlignmentTest_OBJECTS) $(AlignmentTest_DEPENDENCIES) $(EXTRA_AlignmentTest_DEPENDENCIES) 
-	@rm -f AlignmentTest$(EXEEXT)
-	$(AM_V_CXXLD)$(CXXLINK) $(AlignmentTest_OBJECTS) $(AlignmentTest_LDADD) $(LIBS)
-
-ComparisonsTest$(EXEEXT): $(ComparisonsTest_OBJECTS) $(ComparisonsTest_DEPENDENCIES) $(EXTRA_ComparisonsTest_DEPENDENCIES) 
-	@rm -f ComparisonsTest$(EXEEXT)
-	$(AM_V_CXXLD)$(CXXLINK) $(ComparisonsTest_OBJECTS) $(ComparisonsTest_LDADD) $(LIBS)
-
-CountingOperators$(EXEEXT): $(CountingOperators_OBJECTS) $(CountingOperators_DEPENDENCIES) $(EXTRA_CountingOperators_DEPENDENCIES) 
-	@rm -f CountingOperators$(EXEEXT)
-	$(AM_V_CXXLD)$(CXXLINK) $(CountingOperators_OBJECTS) $(CountingOperators_LDADD) $(LIBS)
-
-FastaConstructors$(EXEEXT): $(FastaConstructors_OBJECTS) $(FastaConstructors_DEPENDENCIES) $(EXTRA_FastaConstructors_DEPENDENCIES) 
-	@rm -f FastaConstructors$(EXEEXT)
-	$(AM_V_CXXLD)$(CXXLINK) $(FastaConstructors_OBJECTS) $(FastaConstructors_LDADD) $(LIBS)
-
-FastaIO$(EXEEXT): $(FastaIO_OBJECTS) $(FastaIO_DEPENDENCIES) $(EXTRA_FastaIO_DEPENDENCIES) 
-	@rm -f FastaIO$(EXEEXT)
-	$(AM_V_CXXLD)$(CXXLINK) $(FastaIO_OBJECTS) $(FastaIO_LDADD) $(LIBS)
-
-FastaOperations$(EXEEXT): $(FastaOperations_OBJECTS) $(FastaOperations_DEPENDENCIES) $(EXTRA_FastaOperations_DEPENDENCIES) 
-	@rm -f FastaOperations$(EXEEXT)
-	$(AM_V_CXXLD)$(CXXLINK) $(FastaOperations_OBJECTS) $(FastaOperations_LDADD) $(LIBS)
-
-PolySIMtest$(EXEEXT): $(PolySIMtest_OBJECTS) $(PolySIMtest_DEPENDENCIES) $(EXTRA_PolySIMtest_DEPENDENCIES) 
-	@rm -f PolySIMtest$(EXEEXT)
-	$(AM_V_CXXLD)$(CXXLINK) $(PolySIMtest_OBJECTS) $(PolySIMtest_LDADD) $(LIBS)
-
-PolySNPtest$(EXEEXT): $(PolySNPtest_OBJECTS) $(PolySNPtest_DEPENDENCIES) $(EXTRA_PolySNPtest_DEPENDENCIES) 
-	@rm -f PolySNPtest$(EXEEXT)
-	$(AM_V_CXXLD)$(CXXLINK) $(PolySNPtest_OBJECTS) $(PolySNPtest_LDADD) $(LIBS)
-
-PolySitesIO$(EXEEXT): $(PolySitesIO_OBJECTS) $(PolySitesIO_DEPENDENCIES) $(EXTRA_PolySitesIO_DEPENDENCIES) 
-	@rm -f PolySitesIO$(EXEEXT)
-	$(AM_V_CXXLD)$(CXXLINK) $(PolySitesIO_OBJECTS) $(PolySitesIO_LDADD) $(LIBS)
-
-PolyTableBadBehavior$(EXEEXT): $(PolyTableBadBehavior_OBJECTS) $(PolyTableBadBehavior_DEPENDENCIES) $(EXTRA_PolyTableBadBehavior_DEPENDENCIES) 
-	@rm -f PolyTableBadBehavior$(EXEEXT)
-	$(AM_V_CXXLD)$(CXXLINK) $(PolyTableBadBehavior_OBJECTS) $(PolyTableBadBehavior_LDADD) $(LIBS)
-
-PolyTableConversions$(EXEEXT): $(PolyTableConversions_OBJECTS) $(PolyTableConversions_DEPENDENCIES) $(EXTRA_PolyTableConversions_DEPENDENCIES) 
-	@rm -f PolyTableConversions$(EXEEXT)
-	$(AM_V_CXXLD)$(CXXLINK) $(PolyTableConversions_OBJECTS) $(PolyTableConversions_LDADD) $(LIBS)
-
-PolyTableSliceTest$(EXEEXT): $(PolyTableSliceTest_OBJECTS) $(PolyTableSliceTest_DEPENDENCIES) $(EXTRA_PolyTableSliceTest_DEPENDENCIES) 
-	@rm -f PolyTableSliceTest$(EXEEXT)
-	$(AM_V_CXXLD)$(CXXLINK) $(PolyTableSliceTest_OBJECTS) $(PolyTableSliceTest_LDADD) $(LIBS)
-
-PolyTableTweaking$(EXEEXT): $(PolyTableTweaking_OBJECTS) $(PolyTableTweaking_DEPENDENCIES) $(EXTRA_PolyTableTweaking_DEPENDENCIES) 
-	@rm -f PolyTableTweaking$(EXEEXT)
-	$(AM_V_CXXLD)$(CXXLINK) $(PolyTableTweaking_OBJECTS) $(PolyTableTweaking_LDADD) $(LIBS)
-
-RedundancyCom95test$(EXEEXT): $(RedundancyCom95test_OBJECTS) $(RedundancyCom95test_DEPENDENCIES) $(EXTRA_RedundancyCom95test_DEPENDENCIES) 
-	@rm -f RedundancyCom95test$(EXEEXT)
-	$(AM_V_CXXLD)$(CXXLINK) $(RedundancyCom95test_OBJECTS) $(RedundancyCom95test_LDADD) $(LIBS)
-
-SeqConversions$(EXEEXT): $(SeqConversions_OBJECTS) $(SeqConversions_DEPENDENCIES) $(EXTRA_SeqConversions_DEPENDENCIES) 
-	@rm -f SeqConversions$(EXEEXT)
-	$(AM_V_CXXLD)$(CXXLINK) $(SeqConversions_OBJECTS) $(SeqConversions_LDADD) $(LIBS)
-
-SimpleSNPIO$(EXEEXT): $(SimpleSNPIO_OBJECTS) $(SimpleSNPIO_DEPENDENCIES) $(EXTRA_SimpleSNPIO_DEPENDENCIES) 
-	@rm -f SimpleSNPIO$(EXEEXT)
-	$(AM_V_CXXLD)$(CXXLINK) $(SimpleSNPIO_OBJECTS) $(SimpleSNPIO_LDADD) $(LIBS)
-
-VariantMatrixTest$(EXEEXT): $(VariantMatrixTest_OBJECTS) $(VariantMatrixTest_DEPENDENCIES) $(EXTRA_VariantMatrixTest_DEPENDENCIES) 
-	@rm -f VariantMatrixTest$(EXEEXT)
-	$(AM_V_CXXLD)$(CXXLINK) $(VariantMatrixTest_OBJECTS) $(VariantMatrixTest_LDADD) $(LIBS)
-
-alphabets$(EXEEXT): $(alphabets_OBJECTS) $(alphabets_DEPENDENCIES) $(EXTRA_alphabets_DEPENDENCIES) 
-	@rm -f alphabets$(EXEEXT)
-	$(AM_V_CXXLD)$(CXXLINK) $(alphabets_OBJECTS) $(alphabets_LDADD) $(LIBS)
-
-fastqConstructors$(EXEEXT): $(fastqConstructors_OBJECTS) $(fastqConstructors_DEPENDENCIES) $(EXTRA_fastqConstructors_DEPENDENCIES) 
-	@rm -f fastqConstructors$(EXEEXT)
-	$(AM_V_CXXLD)$(CXXLINK) $(fastqConstructors_OBJECTS) $(fastqConstructors_LDADD) $(LIBS)
-
-fastqIO$(EXEEXT): $(fastqIO_OBJECTS) $(fastqIO_DEPENDENCIES) $(EXTRA_fastqIO_DEPENDENCIES) 
-	@rm -f fastqIO$(EXEEXT)
-	$(AM_V_CXXLD)$(CXXLINK) $(fastqIO_OBJECTS) $(fastqIO_LDADD) $(LIBS)
-
-polySiteVectorTest$(EXEEXT): $(polySiteVectorTest_OBJECTS) $(polySiteVectorTest_DEPENDENCIES) $(EXTRA_polySiteVectorTest_DEPENDENCIES) 
-	@rm -f polySiteVectorTest$(EXEEXT)
-	$(AM_V_CXXLD)$(CXXLINK) $(polySiteVectorTest_OBJECTS) $(polySiteVectorTest_LDADD) $(LIBS)
-
-stateCounterTest$(EXEEXT): $(stateCounterTest_OBJECTS) $(stateCounterTest_DEPENDENCIES) $(EXTRA_stateCounterTest_DEPENDENCIES) 
-	@rm -f stateCounterTest$(EXEEXT)
-	$(AM_V_CXXLD)$(CXXLINK) $(stateCounterTest_OBJECTS) $(stateCounterTest_LDADD) $(LIBS)
-
-testSimDataIO$(EXEEXT): $(testSimDataIO_OBJECTS) $(testSimDataIO_DEPENDENCIES) $(EXTRA_testSimDataIO_DEPENDENCIES) 
-	@rm -f testSimDataIO$(EXEEXT)
-	$(AM_V_CXXLD)$(CXXLINK) $(testSimDataIO_OBJECTS) $(testSimDataIO_LDADD) $(LIBS)
+libseq_unit_tests$(EXEEXT): $(libseq_unit_tests_OBJECTS) $(libseq_unit_tests_DEPENDENCIES) $(EXTRA_libseq_unit_tests_DEPENDENCIES) 
+	@rm -f libseq_unit_tests$(EXEEXT)
+	$(AM_V_CXXLD)$(CXXLINK) $(libseq_unit_tests_OBJECTS) $(libseq_unit_tests_LDADD) $(LIBS)
 
 mostlyclean-compile:
 	-rm -f *.$(OBJEXT)
@@ -876,6 +649,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/alphabets.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/fastqConstructors.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/fastqIO.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libseq_unit_tests.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/polySiteVectorTest.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/stateCounterTest.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/testSimDataIO.Po@am__quote@
@@ -1103,170 +877,9 @@ recheck: all $(check_PROGRAMS)
 	        am__force_recheck=am--force-recheck \
 	        TEST_LOGS="$$log_list"; \
 	exit $$?
-FastaConstructors.log: FastaConstructors$(EXEEXT)
-	@p='FastaConstructors$(EXEEXT)'; \
-	b='FastaConstructors'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-FastaIO.log: FastaIO$(EXEEXT)
-	@p='FastaIO$(EXEEXT)'; \
-	b='FastaIO'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-FastaOperations.log: FastaOperations$(EXEEXT)
-	@p='FastaOperations$(EXEEXT)'; \
-	b='FastaOperations'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-AlignStreamTest.log: AlignStreamTest$(EXEEXT)
-	@p='AlignStreamTest$(EXEEXT)'; \
-	b='AlignStreamTest'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-testSimDataIO.log: testSimDataIO$(EXEEXT)
-	@p='testSimDataIO$(EXEEXT)'; \
-	b='testSimDataIO'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-CountingOperators.log: CountingOperators$(EXEEXT)
-	@p='CountingOperators$(EXEEXT)'; \
-	b='CountingOperators'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-PolyTableConversions.log: PolyTableConversions$(EXEEXT)
-	@p='PolyTableConversions$(EXEEXT)'; \
-	b='PolyTableConversions'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-PolyTableTweaking.log: PolyTableTweaking$(EXEEXT)
-	@p='PolyTableTweaking$(EXEEXT)'; \
-	b='PolyTableTweaking'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-PolyTableBadBehavior.log: PolyTableBadBehavior$(EXEEXT)
-	@p='PolyTableBadBehavior$(EXEEXT)'; \
-	b='PolyTableBadBehavior'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-PolySitesIO.log: PolySitesIO$(EXEEXT)
-	@p='PolySitesIO$(EXEEXT)'; \
-	b='PolySitesIO'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-SimpleSNPIO.log: SimpleSNPIO$(EXEEXT)
-	@p='SimpleSNPIO$(EXEEXT)'; \
-	b='SimpleSNPIO'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-PolySIMtest.log: PolySIMtest$(EXEEXT)
-	@p='PolySIMtest$(EXEEXT)'; \
-	b='PolySIMtest'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-PolySNPtest.log: PolySNPtest$(EXEEXT)
-	@p='PolySNPtest$(EXEEXT)'; \
-	b='PolySNPtest'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-ComparisonsTest.log: ComparisonsTest$(EXEEXT)
-	@p='ComparisonsTest$(EXEEXT)'; \
-	b='ComparisonsTest'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-AlignmentTest.log: AlignmentTest$(EXEEXT)
-	@p='AlignmentTest$(EXEEXT)'; \
-	b='AlignmentTest'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-fastqIO.log: fastqIO$(EXEEXT)
-	@p='fastqIO$(EXEEXT)'; \
-	b='fastqIO'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-fastqConstructors.log: fastqConstructors$(EXEEXT)
-	@p='fastqConstructors$(EXEEXT)'; \
-	b='fastqConstructors'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-SeqConversions.log: SeqConversions$(EXEEXT)
-	@p='SeqConversions$(EXEEXT)'; \
-	b='SeqConversions'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-RedundancyCom95test.log: RedundancyCom95test$(EXEEXT)
-	@p='RedundancyCom95test$(EXEEXT)'; \
-	b='RedundancyCom95test'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-alphabets.log: alphabets$(EXEEXT)
-	@p='alphabets$(EXEEXT)'; \
-	b='alphabets'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-polySiteVectorTest.log: polySiteVectorTest$(EXEEXT)
-	@p='polySiteVectorTest$(EXEEXT)'; \
-	b='polySiteVectorTest'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-PolyTableSliceTest.log: PolyTableSliceTest$(EXEEXT)
-	@p='PolyTableSliceTest$(EXEEXT)'; \
-	b='PolyTableSliceTest'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-stateCounterTest.log: stateCounterTest$(EXEEXT)
-	@p='stateCounterTest$(EXEEXT)'; \
-	b='stateCounterTest'; \
-	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
-	--log-file $$b.log --trs-file $$b.trs \
-	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
-	"$$tst" $(AM_TESTS_FD_REDIRECT)
-VariantMatrixTest.log: VariantMatrixTest$(EXEEXT)
-	@p='VariantMatrixTest$(EXEEXT)'; \
-	b='VariantMatrixTest'; \
+libseq_unit_tests.log: libseq_unit_tests$(EXEEXT)
+	@p='libseq_unit_tests$(EXEEXT)'; \
+	b='libseq_unit_tests'; \
 	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
 	--log-file $$b.log --trs-file $$b.trs \
 	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \

--- a/test/PolySIMtest.cc
+++ b/test/PolySIMtest.cc
@@ -2,11 +2,9 @@
   Validate calculation of summary stats via PolySIM
   by independently recoding them all.  Joy.
  */
-#define BOOST_TEST_MODULE PolySIMtest
-
 #include <Sequence/SimData.hpp>
 #include <Sequence/PolySIM.hpp>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <fstream>
 #include <iostream>
 #include <set>
@@ -15,6 +13,8 @@
 #include <cmath>
 
 const char * testfile = "data/single_ms.txt";
+
+BOOST_AUTO_TEST_SUITE(PolySIMTest)
 
 double pi( const Sequence::SimData & d )
 {
@@ -193,3 +193,4 @@ BOOST_AUTO_TEST_CASE( hapdiv )
   BOOST_REQUIRE_CLOSE( lseqvalue, hdiv, 1e-3);
   BOOST_REQUIRE_CLOSE( lseqvalue, hdiv2, 1e-3);
 }
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/PolySNPtest.cc
+++ b/test/PolySNPtest.cc
@@ -1,14 +1,14 @@
-#define BOOST_TEST_MODULE PolySNPtest
-
 #include <Sequence/PolySites.hpp>
 #include <Sequence/PolySNP.hpp>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <fstream>
 #include <iostream>
 #include <set>
 #include <algorithm>
 #include <limits>
 #include <cmath>
+
+BOOST_AUTO_TEST_SUITE(PolySNPTest)
 
 BOOST_AUTO_TEST_CASE( check_empty_table )
 {
@@ -66,3 +66,4 @@ BOOST_AUTO_TEST_CASE( check_empty_table )
   BOOST_CHECK( std::isnan(ad.HudsonsC()) );
   BOOST_CHECK( ad.Disequilibrium().empty() );
 }
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/PolySitesIO.cc
+++ b/test/PolySitesIO.cc
@@ -1,10 +1,11 @@
-#define BOOST_TEST_MODULE PolySitesIO
-
 #include <Sequence/PolySites.hpp>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <sstream>
 #include <fstream>
 #include <unistd.h>
+
+BOOST_AUTO_TEST_SUITE(PolySitesIOTest)
+
 BOOST_AUTO_TEST_CASE( polysites_io )
 {
   std::vector<double> pos = {1,2,3,4,5};
@@ -33,3 +34,4 @@ BOOST_AUTO_TEST_CASE( polysites_io )
   BOOST_REQUIRE( ps == ps2 );
   unlink(fn);
 }
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/PolyTableBadBehavior.cc
+++ b/test/PolyTableBadBehavior.cc
@@ -7,19 +7,19 @@
   - \ref polytable_idiot
  */
 
-#define BOOST_TEST_MODULE PolyTableBadBehavior
-
 #include <Sequence/PolySites.hpp>
 #include <Sequence/Fasta.hpp>
 #include <Sequence/Alignment.hpp>
 #include <Sequence/polySiteVector.hpp>
 #include <Sequence/PolyTableFunctions.hpp>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <cstdio>
 #include <cstdlib>
 #include <cctype>
 #include <iostream>
 #include <functional>
+
+BOOST_AUTO_TEST_SUITE(PolyTableBadBehaviorTest)
 
 BOOST_AUTO_TEST_CASE( exception1 )
 {
@@ -139,3 +139,4 @@ BOOST_AUTO_TEST_CASE( badness2 )
   //for later actions.
   BOOST_CHECK_EQUAL(Sequence::Alignment::IsAlignment(std::vector<std::string>(ps.begin(),ps.end())), false);
 }
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/PolyTableConversions.cc
+++ b/test/PolyTableConversions.cc
@@ -1,15 +1,15 @@
-#define BOOST_TEST_MODULE PolyTableConversions
-
 #include <Sequence/PolySites.hpp>
 #include <Sequence/SimpleSNP.hpp>
 #include <Sequence/SimData.hpp>
 #include <Sequence/Fasta.hpp>
 #include <Sequence/Alignment.hpp>
 #include <Sequence/PolyTableFunctions.hpp>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <cstdio>
 #include <cstdlib>
 #include <iostream>
+
+BOOST_AUTO_TEST_SUITE(PolyTableConversionsTest)
 
 BOOST_AUTO_TEST_CASE( make_a_table_from_strings )
 {
@@ -258,3 +258,4 @@ BOOST_AUTO_TEST_CASE(test_swap)
   BOOST_CHECK(!ps2.empty());
 }
 
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/PolyTableSliceTest.cc
+++ b/test/PolyTableSliceTest.cc
@@ -1,7 +1,5 @@
 //! \file PolyTableSliceTest.cc @brief Tests for Sequence/PolyTableSlice.hpp
-#define BOOST_TEST_MODULE ComparisonsTest
-
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <Sequence/SimData.hpp>
 #include <iostream>
 #include <Sequence/PolyTableSlice.hpp>
@@ -11,6 +9,8 @@
 
 using namespace std;
 using namespace Sequence;
+
+BOOST_AUTO_TEST_SUITE(PolyTableSliceTest)
 
 BOOST_AUTO_TEST_CASE( lastwindows1 )
 {
@@ -60,3 +60,4 @@ BOOST_AUTO_TEST_CASE( nwindows2 )
 }
 
 
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/PolyTableTweaking.cc
+++ b/test/PolyTableTweaking.cc
@@ -1,10 +1,8 @@
-#define BOOST_TEST_MODULE PolyTableTweaking
-
 #include <Sequence/PolySites.hpp>
 #include <Sequence/Fasta.hpp>
 #include <Sequence/polySiteVector.hpp>
 #include <Sequence/PolyTableFunctions.hpp>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <cstdio>
 #include <cstdlib>
 #include <cctype>
@@ -13,6 +11,8 @@
 
 using namespace Sequence;
 //Removal of N 
+BOOST_AUTO_TEST_SUITE(PolyTableTweakingTest)
+
 BOOST_AUTO_TEST_CASE( remove_missing_N )
 {
   std::vector<double> pos = {1,2,3,4,5};
@@ -502,4 +502,5 @@ BOOST_AUTO_TEST_CASE( remove_invariant )
 }
 
 
+BOOST_AUTO_TEST_SUITE_END()
 

--- a/test/RedundancyCom95test.cc
+++ b/test/RedundancyCom95test.cc
@@ -1,8 +1,6 @@
-#define BOOST_TEST_MODULE RedundancyCom95
-
 #include <Sequence/RedundancyCom95.hpp>
 #include <Sequence/SeqAlphabets.hpp>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -12,6 +10,8 @@
 #include <unistd.h>
 
 //Test that redundancy values sum to 3 for all non-stop codons + universal code
+BOOST_AUTO_TEST_SUITE(RedundancyCom95Test)
+
 BOOST_AUTO_TEST_CASE( universal_code_1 )
 {
   Sequence::RedundancyCom95 rc;
@@ -874,7 +874,4 @@ BOOST_AUTO_TEST_CASE( TTT )
   BOOST_CHECK_EQUAL(rc.Third2S(codon),1.);
   BOOST_CHECK_EQUAL(rc.Third2V(codon),0.);
 }
-
-
-
-
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/Seq8test.cc
+++ b/test/Seq8test.cc
@@ -1,9 +1,7 @@
 /*! \file Seq8test.cc @brief Unit tests for Sequence/Seq.hpp */
-#define BOOST_TEST_MODULE Seq8test
-
 #include <Sequence/Seq8.hpp>
 #include <Sequence/SeqExceptions.hpp>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <algorithm>
 #include <iterator>
 #include <sstream>
@@ -104,4 +102,5 @@ BOOST_AUTO_TEST_CASE( IO_1 )
   BOOST_CHECK( s8.second == s8_2.second );
   BOOST_CHECK_EQUAL( s8.unpack() , s8_2.unpack() );
 }
+BOOST_AUTO_TEST_SUITE_END()
 

--- a/test/SeqConversions.cc
+++ b/test/SeqConversions.cc
@@ -1,11 +1,10 @@
-#define BOOST_TEST_MODULE SeqConverions
-
 #include <Sequence/Fasta.hpp>
 #include <Sequence/fastq.hpp>
 #include <string>
 #include <fstream>
 #include <iostream>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
+BOOST_AUTO_TEST_SUITE(SeqConversionsTest)
 
 BOOST_AUTO_TEST_CASE( fastq2fasta )
 {
@@ -76,3 +75,4 @@ BOOST_AUTO_TEST_CASE( fasta2fastq_3 )
   BOOST_CHECK( fq.second == "ATGC" );
   BOOST_CHECK( fq.quality.empty() );
 }
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/SimpleSNPIO.cc
+++ b/test/SimpleSNPIO.cc
@@ -1,11 +1,12 @@
-#define BOOST_TEST_MODULE SimpleSNPIO
-
 #include <Sequence/PolySites.hpp>
 #include <Sequence/SimpleSNP.hpp>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <sstream>
 #include <fstream>
 #include <unistd.h>
+
+BOOST_AUTO_TEST_SUITE(SimpleSNPIOTest)
+
 BOOST_AUTO_TEST_CASE( polysites_io )
 {
   std::vector<double> pos = {1,2,3,4,5};
@@ -53,3 +54,4 @@ BOOST_AUTO_TEST_CASE( polysites_io )
 
   unlink(fn2);
 }
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/VariantMatrixTest.cc
+++ b/test/VariantMatrixTest.cc
@@ -1,12 +1,12 @@
 //! \file VariantMatrixTest.cc @brief Tests for Sequence/VariantMatrix.hpp
-#define BOOST_TEST_MODULE VariantMatrixTest
-
 #include <Sequence/VariantMatrix.hpp>
 #include <Sequence/VariantMatrixViews.hpp>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <algorithm>
 #include <numeric> //for std::iota
 #include <iterator>
+
+BOOST_AUTO_TEST_SUITE(VariantMatrixTest)
 
 struct vmatrix_fixture
 {
@@ -293,3 +293,4 @@ BOOST_FIXTURE_TEST_CASE(test_accumulate, vmatrix_fixture)
     sum = static_cast<int>(std::accumulate(c.cbegin(), c.cend(), 0));
     BOOST_REQUIRE_EQUAL(sum, 0);
 }
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/alphabets.cc
+++ b/test/alphabets.cc
@@ -1,11 +1,11 @@
 /*! \file alphabets.cc @brief Unit tests for Sequence/SeqAlphabets.hpp */
-#define BOOST_TEST_MODULE alphabets
 
 #include <Sequence/SeqAlphabets.hpp>
 #include <Sequence/Fasta.hpp>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <algorithm>
 #include <iterator>
+BOOST_AUTO_TEST_SUITE(AlphabetTest)
 
 BOOST_AUTO_TEST_CASE( check_dna_alphabet )
 {
@@ -83,3 +83,4 @@ BOOST_AUTO_TEST_CASE( dna_poly_alphabet_5 )
 					    Sequence::dna_poly_alphabet.end(),c) ) >= Sequence::NOTPOLYCHAR );
     }
 }
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/fastqConstructors.cc
+++ b/test/fastqConstructors.cc
@@ -1,13 +1,14 @@
 //\file fastqConstructors.cc
-#define BOOST_TEST_MODULE fastqIO
 
 #include <Sequence/fastq.hpp>
 #include <fstream>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <unistd.h>
 #include <iterator>
 #include <iostream>
 #include <stdexcept>
+
+BOOST_AUTO_TEST_SUITE(FastqConstructorsTest)
 
 BOOST_AUTO_TEST_CASE( move_construction )
 {
@@ -25,3 +26,4 @@ BOOST_AUTO_TEST_CASE( move_construction )
 
   BOOST_CHECK_EQUAL(f.length(),0);
 }
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/fastqIO.cc
+++ b/test/fastqIO.cc
@@ -1,12 +1,14 @@
-#define BOOST_TEST_MODULE fastqIO
 
 #include <Sequence/fastq.hpp>
 #include <fstream>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <unistd.h>
 #include <iterator>
 #include <iostream>
 #include <stdexcept>
+
+BOOST_AUTO_TEST_SUITE(FASTQIOTest)
+
 BOOST_AUTO_TEST_CASE( input_test )
 {
   std::ifstream in("data/data.fastq");
@@ -92,3 +94,4 @@ BOOST_AUTO_TEST_CASE( output_test )
      in.close(); 
      );
 }
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/libseq_unit_tests.cc
+++ b/test/libseq_unit_tests.cc
@@ -1,0 +1,3 @@
+#define BOOST_TEST_MODULE libsequence_unit_tests
+#include <boost/test/included/unit_test.hpp>
+

--- a/test/polySiteVectorTest.cc
+++ b/test/polySiteVectorTest.cc
@@ -1,10 +1,8 @@
 //! \file polySiteVectorTest.cc @brief Unit tests for Sequence::polySiteVector
-#define BOOST_TEST_MODULE polySiteVectorTest
-
 #include <Sequence/polySiteVector.hpp>
 #include <Sequence/PolySites.hpp>
 #include <Sequence/SeqAlphabets.hpp>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <cstdio>
 #include <cstdlib>
 #include <cctype>
@@ -15,6 +13,8 @@
 
 using psite = Sequence::polymorphicSite;
 using Ptable = Sequence::polySiteVector;
+
+BOOST_AUTO_TEST_SUITE(PolySiteVectorTest)
 
 BOOST_AUTO_TEST_CASE( ptable_remove_1 )
 {
@@ -62,3 +62,4 @@ BOOST_AUTO_TEST_CASE( ptable_make_from_polytable )
 
   BOOST_REQUIRE( t == t2 );
 }
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/stateCounterTest.cc
+++ b/test/stateCounterTest.cc
@@ -1,14 +1,13 @@
-#define BOOST_TEST_MODULE stateCounterTest
-
 #include <Sequence/stateCounter.hpp>
 #include <string>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <iostream>
 #include <algorithm>
 #include <functional>
 
 using namespace std;
 using namespace Sequence;
+BOOST_AUTO_TEST_SUITE(stateCounterTest)
 
 BOOST_AUTO_TEST_CASE( test1 )
 {
@@ -23,3 +22,4 @@ BOOST_AUTO_TEST_CASE( test1 )
   BOOST_CHECK_EQUAL(y.gap,1);
   BOOST_CHECK_EQUAL(y.ndna,0);
 }
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/testSimDataIO.cc
+++ b/test/testSimDataIO.cc
@@ -1,156 +1,158 @@
-#define BOOST_TEST_MODULE testSimDataIO
-
 #include <Sequence/SimDataIO.hpp>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <fstream>
 #include <cstdio>
 #include <sstream>
 #include <iterator>
 #include <unistd.h>
 
-const char * infile = "data/single_ms.txt";
-
-BOOST_AUTO_TEST_CASE( SimData_read_stream )
+struct filename_fixture
 {
-  std::ifstream in(infile);
-  Sequence::SimData d;
+    const char* infile;
+    filename_fixture() : infile{ "data/single_ms.txt" } {}
+};
 
-  in >> d >> std::ws; 
-  BOOST_REQUIRE_EQUAL(d.size(),100);
-  BOOST_REQUIRE_EQUAL(d.numsites(),196);
+BOOST_FIXTURE_TEST_SUITE(SimDataIOTest, filename_fixture)
+
+BOOST_AUTO_TEST_CASE(SimData_read_stream)
+{
+    std::ifstream in(infile);
+    Sequence::SimData d;
+
+    in >> d >> std::ws;
+    BOOST_REQUIRE_EQUAL(d.size(), 100);
+    BOOST_REQUIRE_EQUAL(d.numsites(), 196);
 }
 
-BOOST_AUTO_TEST_CASE( SimData_read_stream2 )
+BOOST_AUTO_TEST_CASE(SimData_read_stream2)
 {
-  std::ifstream in(infile);
-  Sequence::SimData d;
-  in >> d >> std::ws; 
-  in.close();
-  BOOST_REQUIRE_EQUAL(d.size(),100);
-  BOOST_REQUIRE_EQUAL(d.numsites(),196);
+    std::ifstream in(infile);
+    Sequence::SimData d;
+    in >> d >> std::ws;
+    in.close();
+    BOOST_REQUIRE_EQUAL(d.size(), 100);
+    BOOST_REQUIRE_EQUAL(d.numsites(), 196);
 
-  const char * outfile = "SimDataTest.txt";
-  std::ofstream out(outfile);
-  //no new line at end, for extra challenge
-  out << d << '\n' << d;
-  out.close();
-  unsigned count = 0;
-  in.open(outfile);
-  if(!in) std::exit(1);
-  BOOST_REQUIRE_NO_THROW (
-			  while(!in.eof())
-			  {
-			    in >> d >> std::ws;
-			    ++count;
-			  }
-			  );
-  BOOST_REQUIRE_EQUAL(count,2);
-  in.close();
-  unlink(outfile);
+    const char* outfile = "SimDataTest.txt";
+    std::ofstream out(outfile);
+    //no new line at end, for extra challenge
+    out << d << '\n' << d;
+    out.close();
+    unsigned count = 0;
+    in.open(outfile);
+    if (!in)
+        std::exit(1);
+    BOOST_REQUIRE_NO_THROW(while (!in.eof()) {
+        in >> d >> std::ws;
+        ++count;
+    });
+    BOOST_REQUIRE_EQUAL(count, 2);
+    in.close();
+    unlink(outfile);
 }
 
-BOOST_AUTO_TEST_CASE( SimData_read_stream3 )
+BOOST_AUTO_TEST_CASE(SimData_read_stream3)
 {
 
-  std::ifstream in(infile);
-  Sequence::SimData d;
-  in >> d >> std::ws; 
-  in.close();
-  BOOST_REQUIRE_EQUAL(d.size(),100);
-  BOOST_REQUIRE_EQUAL(d.numsites(),196);
+    std::ifstream in(infile);
+    Sequence::SimData d;
+    in >> d >> std::ws;
+    in.close();
+    BOOST_REQUIRE_EQUAL(d.size(), 100);
+    BOOST_REQUIRE_EQUAL(d.numsites(), 196);
 
-  const char * outfile = "SimDataTest.txt";
-  std::ofstream out(outfile);
-  //no new line at end, for extra challenge
-  out << d << '\n' << d;
-  out.close();
-  unsigned count = 0;
-  in.open(outfile);
-  if(!in) std::exit(1);
-  BOOST_REQUIRE_NO_THROW (
-			  std::istream_iterator<Sequence::SimData> i(in);
-			  for( ; i != std::istream_iterator<Sequence::SimData>() ; ++i )
-			    {
-			      BOOST_CHECK( *i == d );
-			      ++count;  
-			    }
-			  );
-  BOOST_CHECK_EQUAL(count,2);
-  in.close();
-  unlink(outfile);
+    const char* outfile = "SimDataTest.txt";
+    std::ofstream out(outfile);
+    //no new line at end, for extra challenge
+    out << d << '\n' << d;
+    out.close();
+    unsigned count = 0;
+    in.open(outfile);
+    if (!in)
+        std::exit(1);
+    BOOST_REQUIRE_NO_THROW(
+        std::istream_iterator<Sequence::SimData> i(in);
+        for (; i != std::istream_iterator<Sequence::SimData>(); ++i) {
+            BOOST_CHECK(*i == d);
+            ++count;
+        });
+    BOOST_CHECK_EQUAL(count, 2);
+    in.close();
+    unlink(outfile);
 }
 
-BOOST_AUTO_TEST_CASE( SimData_read_FILE )
+BOOST_AUTO_TEST_CASE(SimData_read_FILE)
 {
-  FILE * fp = fopen(infile,"r");
-  Sequence::SimData d;
-  d.fromfile(fp);
-  fclose(fp);
+    FILE* fp = fopen(infile, "r");
+    Sequence::SimData d;
+    d.fromfile(fp);
+    fclose(fp);
 
-  BOOST_REQUIRE_EQUAL(d.size(),100);
-  BOOST_REQUIRE_EQUAL(d.numsites(),196);
+    BOOST_REQUIRE_EQUAL(d.size(), 100);
+    BOOST_REQUIRE_EQUAL(d.numsites(), 196);
 }
 
-BOOST_AUTO_TEST_CASE( SimData_read_same )
+BOOST_AUTO_TEST_CASE(SimData_read_same)
 {
-  std::ifstream in(infile);
-  Sequence::SimData d,d2;
-  in >> d >> std::ws;
-  in.close();
-  BOOST_REQUIRE_EQUAL(d.size(),100);
-  BOOST_REQUIRE_EQUAL(d.numsites(),196);
+    std::ifstream in(infile);
+    Sequence::SimData d, d2;
+    in >> d >> std::ws;
+    in.close();
+    BOOST_REQUIRE_EQUAL(d.size(), 100);
+    BOOST_REQUIRE_EQUAL(d.numsites(), 196);
 
-  FILE * fp = fopen(infile,"r");
-  d2.fromfile(fp);
-  fclose(fp);
+    FILE* fp = fopen(infile, "r");
+    d2.fromfile(fp);
+    fclose(fp);
 
-  BOOST_REQUIRE(d == d2);
+    BOOST_REQUIRE(d == d2);
 }
 
-BOOST_AUTO_TEST_CASE( SimData_binaryIO )
+BOOST_AUTO_TEST_CASE(SimData_binaryIO)
 {
-  std::ifstream in(infile);
-  Sequence::SimData d,d2;
-  in >> d >> std::ws;
-  in.close();
+    std::ifstream in(infile);
+    Sequence::SimData d, d2;
+    in >> d >> std::ws;
+    in.close();
 
-  std::ostringstream out;
-  Sequence::write_SimData_binary(out,d);
-  std::istringstream in2(out.str());
-  d2 = Sequence::read_SimData_binary(in2);
+    std::ostringstream out;
+    Sequence::write_SimData_binary(out, d);
+    std::istringstream in2(out.str());
+    d2 = Sequence::read_SimData_binary(in2);
 
-  BOOST_REQUIRE( d==d2 );
+    BOOST_REQUIRE(d == d2);
 }
 
-BOOST_AUTO_TEST_CASE( SimData_gzipIO )
+BOOST_AUTO_TEST_CASE(SimData_gzipIO)
 {
-  std::ifstream in(infile);
-  Sequence::SimData d,d2;
-  in >> d >> std::ws;
-  in.close();
+    std::ifstream in(infile);
+    Sequence::SimData d, d2;
+    in >> d >> std::ws;
+    in.close();
 
-  const char * outfile = "SimDataTest.gz";
-  //gzipped ASCI
-  gzFile gzfile = gzopen(outfile,"w");
-  auto x = write_SimData_gz(gzfile,d,false);
-  gzclose(gzfile);
-  BOOST_REQUIRE( x > 0 );
-  
-  gzfile = gzopen(outfile,"r");
-  d2 = Sequence::read_SimData_gz(gzfile);
-  gzclose(gzfile);
-  BOOST_REQUIRE(d2 == d);
+    const char* outfile = "SimDataTest.gz";
+    //gzipped ASCI
+    gzFile gzfile = gzopen(outfile, "w");
+    auto x = write_SimData_gz(gzfile, d, false);
+    gzclose(gzfile);
+    BOOST_REQUIRE(x > 0);
 
-  //gzipped binary
-  gzfile = gzopen(outfile,"w");
-  x = write_SimData_gz(gzfile,d,true);
-  gzclose(gzfile);
-  BOOST_REQUIRE( x > 0 );
+    gzfile = gzopen(outfile, "r");
+    d2 = Sequence::read_SimData_gz(gzfile);
+    gzclose(gzfile);
+    BOOST_REQUIRE(d2 == d);
 
-  gzfile = gzopen(outfile,"r");
-  d2 = Sequence::read_SimData_gz(gzfile,true);
-  gzclose(gzfile);
-  BOOST_REQUIRE(d2 == d);
+    //gzipped binary
+    gzfile = gzopen(outfile, "w");
+    x = write_SimData_gz(gzfile, d, true);
+    gzclose(gzfile);
+    BOOST_REQUIRE(x > 0);
 
-  unlink(outfile);
+    gzfile = gzopen(outfile, "r");
+    d2 = Sequence::read_SimData_gz(gzfile, true);
+    gzclose(gzfile);
+    BOOST_REQUIRE(d2 == d);
+
+    unlink(outfile);
 }
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Moves all unit tests into a single driver, greatly improving compilation times.  This will fix #.