### PR TITLE
Stats performance

### DIFF
--- a/Sequence/summstats/Makefile.am
+++ b/Sequence/summstats/Makefile.am
@@ -1,4 +1,5 @@
 pkgincludedir=$(prefix)/include/Sequence/summstats
 
 pkginclude_HEADERS = classics.hpp thetapi.hpp thetaw.hpp thetah.hpp thetal.hpp auxillary.hpp nvariablesites.hpp allele_counts.hpp \
-					 util.hpp ld.hpp nsl.hpp garud.hpp generic.hpp
+					 util.hpp ld.hpp nsl.hpp garud.hpp generic.hpp \
+					 algorithm.hpp

--- a/Sequence/summstats/Makefile.in
+++ b/Sequence/summstats/Makefile.in
@@ -294,7 +294,8 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 pkginclude_HEADERS = classics.hpp thetapi.hpp thetaw.hpp thetah.hpp thetal.hpp auxillary.hpp nvariablesites.hpp allele_counts.hpp \
-					 util.hpp ld.hpp nsl.hpp garud.hpp generic.hpp
+					 util.hpp ld.hpp nsl.hpp garud.hpp generic.hpp \
+					 algorithm.hpp
 
 all: all-am
 

--- a/Sequence/summstats/algorithm.hpp
+++ b/Sequence/summstats/algorithm.hpp
@@ -1,3 +1,6 @@
+/*!
+\file summstats/algorithm.hpp
+*/
 #ifndef SEQUENCE_SUMMSTATS_ALGORITHM_HPP
 #define SEQUENCE_SUMMSTATS_ALGORITHM_HPP
 
@@ -14,6 +17,30 @@ namespace Sequence
         inline void
         aggregate_sites(const VariantMatrix& m, const F& f,
                         const std::int8_t refstate)
+        /*! Helper algorithm for implementing summary statistics.
+         *
+         *  Several common summary statistics are combinations of
+         *  others.  Examples include Tajima's D, Fay and Wu's H,
+         *  etc..  If we take D as an example, it is tempting to
+         *  use existing functions, such as Sequence::thetapi and
+         *  Sequence::thetaw, as intermediate steps.
+         *  However, doing so goes over the data multiple times.  
+         *
+         *  Fortunately, these statistics are often easy enough to 
+         *  implement that we could calculate pi and Watterson's theta 
+         *  in one loop.  This function helps you do that.
+         *  
+         *  \param m A VariantMatrix
+         *  \param f A function taking a const StateCounts & and returning nothing.
+         *  \param refstate The reference state.
+         *
+         *  This function loops over \a m.nsites and passes the state counts on
+         *  to the aggregator function \a f.
+         *
+         *  See the implementation of Sequence::tajd for an example.
+         *
+         *  \ingroup popgenanalysis
+         */
         {
             StateCounts c(refstate);
             for (std::size_t i = 0; i < m.nsites; ++i)

--- a/Sequence/summstats/algorithm.hpp
+++ b/Sequence/summstats/algorithm.hpp
@@ -50,6 +50,51 @@ namespace Sequence
                     f(c);
                 }
         }
+
+        template <typename F>
+        inline void
+        aggregate_sites(const VariantMatrix& m, const F& f,
+                        const std::vector<std::int8_t>& refstates)
+        /*! Helper algorithm for implementing summary statistics.
+         *
+         *  Several common summary statistics are combinations of
+         *  others.  Examples include Tajima's D, Fay and Wu's H,
+         *  etc..  If we take D as an example, it is tempting to
+         *  use existing functions, such as Sequence::thetapi and
+         *  Sequence::thetaw, as intermediate steps.
+         *  However, doing so goes over the data multiple times.  
+         *
+         *  Fortunately, these statistics are often easy enough to 
+         *  implement that we could calculate pi and Watterson's theta 
+         *  in one loop.  This function helps you do that.
+         *  
+         *  \param m A VariantMatrix
+         *  \param f A function taking a const StateCounts & and returning nothing.
+         *  \param refstates Vector of reference states
+         *
+         *  This function loops over \a m.nsites and passes the state counts on
+         *  to the aggregator function \a f.
+         *
+         *  See the implementation of Sequence::hprime for an example.
+         *
+         *  \ingroup popgenanalysis
+         */
+        {
+            if (refstates.size() != m.nsites)
+                {
+                    throw std::invalid_argument(
+                        "number of reference states must equal number of "
+                        "sites in VariantMatrix");
+                }
+            StateCounts c;
+            for (std::size_t i = 0; i < m.nsites; ++i)
+                {
+                    c.refstate = refstates[i];
+                    auto r = get_ConstRowView(m, i);
+                    c(r);
+                    f(c);
+                }
+        }
     } // namespace sstats_algo
 } // namespace Sequence
 

--- a/Sequence/summstats/algorithm.hpp
+++ b/Sequence/summstats/algorithm.hpp
@@ -1,0 +1,29 @@
+#ifndef SEQUENCE_SUMMSTATS_ALGORITHM_HPP
+#define SEQUENCE_SUMMSTATS_ALGORITHM_HPP
+
+#include <cstdint>
+#include <Sequence/VariantMatrix.hpp>
+#include <Sequence/StateCounts.hpp>
+#include <Sequence/VariantMatrixViews.hpp>
+
+namespace Sequence
+{
+    namespace sstats_algo
+    {
+        template <typename F>
+        inline void
+        aggregate_sites(const VariantMatrix& m, const F& f,
+                        const std::int8_t refstate)
+        {
+            StateCounts c(refstate);
+            for (std::size_t i = 0; i < m.nsites; ++i)
+                {
+                    auto r = get_ConstRowView(m, i);
+                    c(r);
+                    f(c);
+                }
+        }
+    } // namespace sstats_algo
+} // namespace Sequence
+
+#endif

--- a/src/summstats/faywuh.cc
+++ b/src/summstats/faywuh.cc
@@ -1,29 +1,30 @@
-#include <Sequence/summstats/thetah.hpp>
-#include <Sequence/summstats/thetapi.hpp>
+#include <functional>
+#include <Sequence/summstats/algorithm.hpp>
+#include "hprime_faywuh_aggregator.hpp"
 
 namespace Sequence
 {
     double
     faywuh(const VariantMatrix& m, const std::int8_t refstate)
     {
-        auto pi = thetapi(m);
-        auto h = thetah(m, refstate);
-        if (pi == 0.0)
+        detail::hprime_faywuh_aggregator agg(2.0);
+        sstats_algo::aggregate_sites(m, std::ref(agg), refstate);
+        if (agg.pi == 0.0)
             {
                 return std::numeric_limits<double>::quiet_NaN();
             }
-        return pi - h;
+        return agg.pi - agg.theta;
     }
 
     double
     faywuh(const VariantMatrix& m, const std::vector<std::int8_t>& refstates)
     {
-        auto pi = thetapi(m);
-        auto h = thetah(m, refstates);
-        if (pi == 0.0)
+        detail::hprime_faywuh_aggregator agg(2.0);
+        sstats_algo::aggregate_sites(m, std::ref(agg), refstates);
+        if (agg.pi == 0.0)
             {
                 return std::numeric_limits<double>::quiet_NaN();
             }
-        return pi - h;
+        return agg.pi - agg.theta;
     }
 } // namespace Sequence

--- a/src/summstats/hprime.cc
+++ b/src/summstats/hprime.cc
@@ -1,16 +1,16 @@
 #include <cmath>
+#include <functional>
+#include <Sequence/summstats/algorithm.hpp>
+#include "hprime_faywuh_aggregator.hpp"
 #include <Sequence/VariantMatrix.hpp>
 #include <Sequence/VariantMatrixViews.hpp>
-#include <Sequence/summstats/thetapi.hpp>
-#include <Sequence/summstats/thetal.hpp>
-#include <Sequence/summstats/nvariablesites.hpp>
 #include <Sequence/summstats/auxillary.hpp>
 
 namespace
 {
     double
-    hprime_common(const Sequence::VariantMatrix &m, const double tp,
-                  const double tl)
+    hprime_common(const Sequence::VariantMatrix &m, const unsigned S,
+                  const double tp, const double tl)
     {
         using namespace Sequence;
         if (tp == 0.0)
@@ -22,9 +22,6 @@ namespace
         auto b1
             = summstats_aux::b_sub_n_plus1(static_cast<std::uint32_t>(m.nsam));
 
-        //Count number of bi-allelic sites
-        //TODO: generalize this
-        auto S = nbiallelic_sites(m);
         double tw
             = static_cast<double>(S) / a; //TODO: replace with call to thetaw
         double tsq = S * (S - 1) / (a * a + b);
@@ -49,16 +46,16 @@ namespace Sequence
     double
     hprime(const VariantMatrix &m, const std::int8_t refstate)
     {
-        auto tp = thetapi(m);
-        auto tl = thetal(m, refstate);
-        return hprime_common(m, tp, tl);
+        detail::hprime_faywuh_aggregator hp(1.0);
+        sstats_algo::aggregate_sites(m, std::ref(hp), refstate);
+        return hprime_common(m, hp.S, hp.pi, hp.theta);
     }
 
     double
     hprime(const VariantMatrix &m, const std::vector<std::int8_t> &refstates)
     {
-        auto tp = thetapi(m);
-        auto tl = thetal(m, refstates);
-        return hprime_common(m, tp, tl);
+        detail::hprime_faywuh_aggregator hp(1.0);
+        sstats_algo::aggregate_sites(m, std::ref(hp), refstates);
+        return hprime_common(m, hp.S, hp.pi, hp.theta);
     }
 } // namespace Sequence

--- a/src/summstats/hprime_faywuh_aggregator.hpp
+++ b/src/summstats/hprime_faywuh_aggregator.hpp
@@ -1,0 +1,67 @@
+#ifndef SEQUENCE_DETAIL_HPRIME_FAYWUH_AGGREGATOR_HPP
+#define SEQUENCE_DETAIL_HPRIME_FAYWUH_AGGREGATOR_HPP
+
+#include <cmath>
+#include <Sequence/StateCounts.hpp>
+
+namespace Sequence
+{
+    namespace detail
+    {
+        struct hprime_faywuh_aggregator
+        {
+            unsigned S;
+            double pi, theta;
+            const double power;
+            hprime_faywuh_aggregator(const double p)
+                : S{ 0 }, pi{ 0.0 }, theta{ 0.0 }, power{ p }
+            {
+            }
+
+            inline void
+            operator()(const Sequence::StateCounts &c)
+            {
+                unsigned nstates = 0;
+                bool refseen = false;
+                double temp = 0.0;
+                double homozygosity = 0.0;
+                for (std::size_t i = 0; i < c.counts.size(); ++i)
+                    {
+                        auto ci = c.counts[i];
+                        if (ci > 0)
+                            {
+                                homozygosity
+                                    += static_cast<double>(ci * (ci - 1));
+                                ++nstates;
+                                if (static_cast<std::int8_t>(i) != c.refstate)
+                                    {
+                                        temp += std::pow(static_cast<double>(i),power);
+                                    }
+                                else
+                                    {
+                                        refseen = true;
+                                    }
+                            }
+                    }
+                if (nstates > 2)
+                    {
+                        throw std::runtime_error(
+                            "site has more than one derived state");
+                    }
+
+                if (nstates > 1)
+                    {
+                        ++S;
+                    }
+                if (refseen)
+                    {
+                        double nnm1 = static_cast<double>(c.n * (c.n - 1));
+                        pi += 1.0 - homozygosity / nnm1;
+                        theta += temp / nnm1;
+                    }
+            }
+        };
+    } // namespace detail
+} // namespace Sequence
+
+#endif

--- a/src/summstats/hprime_faywuh_aggregator.hpp
+++ b/src/summstats/hprime_faywuh_aggregator.hpp
@@ -35,7 +35,8 @@ namespace Sequence
                                 ++nstates;
                                 if (static_cast<std::int8_t>(i) != c.refstate)
                                     {
-                                        temp += std::pow(static_cast<double>(i),power);
+                                        temp += std::pow(
+                                            static_cast<double>(ci), power);
                                     }
                                 else
                                     {

--- a/src/summstats/tajd.cc
+++ b/src/summstats/tajd.cc
@@ -1,22 +1,43 @@
 #include <cmath>
 #include <limits>
-#include <Sequence/summstats/thetapi.hpp>
-#include <Sequence/summstats/thetaw.hpp>
-#include <Sequence/summstats/nvariablesites.hpp>
+#include <Sequence/summstats/algorithm.hpp>
+#include <Sequence/StateCounts.hpp>
+#include <Sequence/VariantMatrixViews.hpp>
 #include <Sequence/summstats/auxillary.hpp>
+
 namespace Sequence
 {
     double
     tajd(const VariantMatrix& m)
     {
-        auto S = total_number_of_mutations(m);
-        if (S == 0)
+        unsigned S = 0;
+        double pi = 0.0;
+        const auto agg = [&S, &pi](const StateCounts& c) {
+            unsigned nstates = 0;
+            double homozygosity = 0.0;
+            for (auto i : c.counts)
+                {
+                    if (i)
+                        {
+                            nstates++;
+                            homozygosity += static_cast<double>(i)
+                                            * static_cast<double>(i - 1);
+                        }
+                }
+            if (nstates > 1)
+                {
+                    S += nstates - 1;
+                    double d = static_cast<double>(c.n * (c.n - 1));
+                    pi += (1.0 - homozygosity / d);
+                }
+        };
+        sstats_algo::aggregate_sites(m, agg, -1);
+        if (!S)
             {
                 return std::numeric_limits<double>::quiet_NaN();
             }
-        auto w = thetaw(m);
-        auto pi = thetapi(m);
         auto a1 = summstats_aux::a_sub_n(static_cast<std::uint32_t>(m.nsam));
+        double w = static_cast<double>(S) / a1;
         auto a2 = summstats_aux::b_sub_n(static_cast<std::uint32_t>(m.nsam));
         auto dn = static_cast<double>(m.nsam);
         double b1 = (dn + 1.0) / (3.0 * (dn - 1.0));

--- a/test/testClassicSummstats.cc
+++ b/test/testClassicSummstats.cc
@@ -174,6 +174,20 @@ BOOST_AUTO_TEST_CASE(test_thetah)
     BOOST_CHECK_CLOSE(h1, m1, 1e-6);
 }
 
+BOOST_AUTO_TEST_CASE(test_faywuh)
+// Fay and Wu's H is calculated using
+// an aggregation distinct from
+// thetah and thetapi.  That means
+// we can compare results from the various functions
+// in order to test.
+{
+    auto h = Sequence::thetah(m, 0);
+    auto pi = Sequence::thetapi(m);
+    auto fwh = Sequence::faywuh(m, 0);
+    BOOST_CHECK_EQUAL(fwh + h, pi);
+    BOOST_REQUIRE_EQUAL(pi - h, fwh);
+}
+
 BOOST_AUTO_TEST_CASE(test_thetah_multiple_derived_states)
 {
     // Create a site with > 2 derived states
@@ -214,15 +228,16 @@ BOOST_AUTO_TEST_CASE(test_unique_hap_at_any_index)
                 }
             auto nh = Sequence::number_of_haplotypes(m2);
             std::vector<std::string> haps;
-            for(std::size_t j=0;j<m2.nsam;++j)
-            {
-                auto cvj = Sequence::get_ConstColView(m2,j);
-                std::string h;
-                for(auto state : cvj) h += state;
-                haps.push_back(std::move(h));
-            }
-            std::set<std::string> uhaps(haps.begin(),haps.end());
-            BOOST_REQUIRE_EQUAL(uhaps.size(),nh);
+            for (std::size_t j = 0; j < m2.nsam; ++j)
+                {
+                    auto cvj = Sequence::get_ConstColView(m2, j);
+                    std::string h;
+                    for (auto state : cvj)
+                        h += state;
+                    haps.push_back(std::move(h));
+                }
+            std::set<std::string> uhaps(haps.begin(), haps.end());
+            BOOST_REQUIRE_EQUAL(uhaps.size(), nh);
         }
 }
 


### PR DESCRIPTION
This PR is a performance audit of summary stat functions introduced in 1.9.4.  That release focused on code re-use for correctness.  Now, we can focus on performance.  This builds on #46 and introduces the idea of aggregating a function over sites.