### PR TITLE
Allele counting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,15 @@
 *.lo
 *~
 Makefile
+*.deps
+*.libs
+*.cache
+config.h
+*.log
+*.status
+libtool
+*.dirstamp
+*.la
+*.trs
+*.doxygen
+stamp-h1

--- a/Sequence/AlleleCountMatrix.hpp
+++ b/Sequence/AlleleCountMatrix.hpp
@@ -17,6 +17,7 @@ namespace Sequence
 
       public:
         const std::vector<std::int32_t> counts;
+        using value_type = std::vector<std::int32_t>::value_type;
         const std::size_t ncol;
         const std::size_t nrow;
         const std::size_t nsam;

--- a/Sequence/AlleleCountMatrix.hpp
+++ b/Sequence/AlleleCountMatrix.hpp
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <vector>
+#include <utility>
 #include <Sequence/VariantMatrix.hpp>
 
 namespace Sequence
@@ -20,7 +21,10 @@ namespace Sequence
         const std::size_t nrow;
         const std::size_t nsam;
         explicit AlleleCountMatrix(const VariantMatrix& m);
+        std::pair<std::vector<std::int32_t>::const_iterator,
+                  std::vector<std::int32_t>::const_iterator>
+        row(const std::size_t) const;
     };
-}
+} // namespace Sequence
 
 #endif

--- a/Sequence/AlleleCountMatrix.hpp
+++ b/Sequence/AlleleCountMatrix.hpp
@@ -16,7 +16,8 @@ namespace Sequence
 
       public:
         const std::vector<std::int32_t> counts;
-        const std::size_t row_size;
+        const std::size_t ncol;
+        const std::size_t nrow;
         const std::size_t nsam;
         explicit AlleleCountMatrix(const VariantMatrix& m);
     };

--- a/Sequence/AlleleCountMatrix.hpp
+++ b/Sequence/AlleleCountMatrix.hpp
@@ -1,0 +1,25 @@
+#ifndef SEQUENCE_ALLELE_COUNT_MATRIX_HPP
+#define SEQUENCE_ALLELE_COUNT_MATRIX_HPP
+
+#include <cstdint>
+#include <vector>
+#include <Sequence/VariantMatrix.hpp>
+
+namespace Sequence
+{
+    class AlleleCountMatrix
+    /// \brief Matrix representation of allele counts in a VariantMatrix
+    /// To be constructed
+    {
+      private:
+        static std::vector<std::int32_t> init_counts(const VariantMatrix& m);
+
+      public:
+        const std::vector<std::int32_t> counts;
+        const std::size_t row_size;
+        const std::size_t nsam;
+        explicit AlleleCountMatrix(const VariantMatrix& m);
+    };
+}
+
+#endif

--- a/Sequence/Makefile.am
+++ b/Sequence/Makefile.am
@@ -57,5 +57,6 @@ pkginclude_HEADERS = AlignStream.hpp\
 	SeqAlphabets.hpp \
 	VariantMatrix.hpp \
 	VariantMatrixViews.hpp \
+	AlleleCountMatrix.hpp \
 	summstats.hpp \
 	StateCounts.hpp

--- a/Sequence/Makefile.in
+++ b/Sequence/Makefile.in
@@ -391,6 +391,7 @@ pkginclude_HEADERS = AlignStream.hpp\
 	SeqAlphabets.hpp \
 	VariantMatrix.hpp \
 	VariantMatrixViews.hpp \
+	AlleleCountMatrix.hpp \
 	summstats.hpp \
 	StateCounts.hpp
 

--- a/Sequence/StateCounts.hpp
+++ b/Sequence/StateCounts.hpp
@@ -25,6 +25,8 @@ namespace Sequence
             = std::numeric_limits<VariantMatrix::value_type>::max();
         /// Keep track of (state, count) pairs
         std::vector<std::int32_t> counts;
+        /// The max allelic value seen
+        std::size_t max_allele_idx;
         /// The sample size at this site.  Excluded missing data.
         std::uint32_t n;
         /// The reference state for this site.  Needed for certain summary

--- a/Sequence/VariantMatrix.hpp
+++ b/Sequence/VariantMatrix.hpp
@@ -1,6 +1,7 @@
 #ifndef SEQUENCE_VARIANT_MATRIX_HPP__
 #define SEQUENCE_VARIANT_MATRIX_HPP__
 
+#include <algorithm>
 #include <cstdint>
 #include <cstddef>
 #include <utility>
@@ -18,7 +19,7 @@ namespace Sequence
     /// \brief Representation and manipulation of variation data.
     /// \ingroup popgen
 
-    struct VariantMatrix
+    class VariantMatrix
     /// \brief Matrix representation of variation data.
     ///
     /// The data structure is a row-major matrix.
@@ -42,6 +43,19 @@ namespace Sequence
     /// \ingroup variantmatrix
     /// \version 1.9.2
     {
+      private:
+        std::int8_t
+        set_max_allele(const std::int8_t max_allele_value)
+        {
+            if (max_allele_value < 0 && !data.empty())
+                {
+                    auto itr = std::max_element(data.begin(), data.end());
+                    return *itr;
+                }
+            return max_allele_value;
+        }
+
+      public:
         /// Data stored in matrix form with rows as sites.
         std::vector<std::int8_t> data;
         /// Position of sites.
@@ -55,16 +69,20 @@ namespace Sequence
         /// The value type of the data.
         /// Helpful for generic programming
         using value_type = std::int8_t;
-
+        /// Max allelic value stored in matrix
+        const std::int8_t max_allele;
         template <typename data_input, typename positions_input>
-        VariantMatrix(data_input&& data_, positions_input&& positions_)
+        VariantMatrix(data_input&& data_, positions_input&& positions_,
+                      const std::int8_t max_allele_value = -1)
             /// \brief "Perfect-forwarding" constructor.
             ///
             /// std::invalid_argument will be thrown if
             /// data.size() % positions.size() != 0.0.
             : data(std::forward<data_input>(data_)),
               positions(std::forward<positions_input>(positions_)),
-              nsites(positions.size()), nsam(data.size() / positions.size())
+              nsites(positions.size()),
+              nsam(data.size() / positions.size()), max_allele{ set_max_allele(
+                                                        max_allele_value) }
         {
             if ((!data.empty() && !positions.empty())
                 && data.size() % positions.size() != 0.0)
@@ -91,6 +109,21 @@ namespace Sequence
         /// std::out_of_range is thrown if indexes are invalid.
         const std::int8_t& at(const std::size_t site,
                               const std::size_t haplotype) const;
+
+        //AlleleCountMatrix count_alleles() const;
+    };
+
+    class AlleleCountMatrix
+    /// \brief Matrix representation of allele counts in a VariantMatrix
+    /// To be constructed
+    {
+      private:
+        static std::vector<std::int32_t> init_counts(const VariantMatrix& m);
+
+      public:
+        const std::vector<std::int32_t> counts;
+        const std::size_t row_size;
+        AlleleCountMatrix(const VariantMatrix& m);
     };
 } // namespace Sequence
 

--- a/Sequence/VariantMatrix.hpp
+++ b/Sequence/VariantMatrix.hpp
@@ -52,6 +52,13 @@ namespace Sequence
                     auto itr = std::max_element(data.begin(), data.end());
                     return *itr;
                 }
+            //special case to allow construction of empty data sets
+            //without throwing an exception
+            else if (data.empty())
+
+                {
+                    return 0;
+                }
             return max_allele_value;
         }
 
@@ -84,6 +91,10 @@ namespace Sequence
               nsam(data.size() / positions.size()), max_allele{ set_max_allele(
                                                         max_allele_value) }
         {
+            if (max_allele < 0)
+                {
+                    throw std::invalid_argument("max allele must be >= 0");
+                }
             if ((!data.empty() && !positions.empty())
                 && data.size() % positions.size() != 0.0)
                 {

--- a/Sequence/VariantMatrix.hpp
+++ b/Sequence/VariantMatrix.hpp
@@ -135,7 +135,7 @@ namespace Sequence
         const std::vector<std::int32_t> counts;
         const std::size_t row_size;
         const std::size_t nsam;
-        AlleleCountMatrix(const VariantMatrix& m);
+        explicit AlleleCountMatrix(const VariantMatrix& m);
     };
 } // namespace Sequence
 

--- a/Sequence/VariantMatrix.hpp
+++ b/Sequence/VariantMatrix.hpp
@@ -120,23 +120,8 @@ namespace Sequence
         /// std::out_of_range is thrown if indexes are invalid.
         const std::int8_t& at(const std::size_t site,
                               const std::size_t haplotype) const;
-
-        //AlleleCountMatrix count_alleles() const;
     };
 
-    class AlleleCountMatrix
-    /// \brief Matrix representation of allele counts in a VariantMatrix
-    /// To be constructed
-    {
-      private:
-        static std::vector<std::int32_t> init_counts(const VariantMatrix& m);
-
-      public:
-        const std::vector<std::int32_t> counts;
-        const std::size_t row_size;
-        const std::size_t nsam;
-        explicit AlleleCountMatrix(const VariantMatrix& m);
-    };
 } // namespace Sequence
 
 #endif

--- a/Sequence/VariantMatrix.hpp
+++ b/Sequence/VariantMatrix.hpp
@@ -134,6 +134,7 @@ namespace Sequence
       public:
         const std::vector<std::int32_t> counts;
         const std::size_t row_size;
+        const std::size_t nsam;
         AlleleCountMatrix(const VariantMatrix& m);
     };
 } // namespace Sequence

--- a/Sequence/summstats/allele_counts.hpp
+++ b/Sequence/summstats/allele_counts.hpp
@@ -6,7 +6,7 @@
 #include <vector>
 #include <utility>
 #include <cstdint>
-#include <Sequence/VariantMatrix.hpp>
+#include <Sequence/AlleleCountMatrix.hpp>
 
 namespace Sequence
 {
@@ -21,27 +21,27 @@ namespace Sequence
     };
 
     /*! \brief Count number of alleles at each site
-     * \param m A VariantMatrix
+     * \param m An AlleleCountMatrix
      * \ingroup popgenanalysis
      */
-    std::vector<AlleleCounts> allele_counts(const VariantMatrix& m);
+    std::vector<AlleleCounts> allele_counts(const AlleleCountMatrix& m);
 
     /*! \brief Count number of non-reference alleles at each site
-     * \param m A VariantMatrix
+     * \param m An AlleleCountMatrix
      * \param m refstate The reference state for all sites.
      * \ingroup popgenanalysis
      */
     std::vector<AlleleCounts>
-    non_reference_allele_counts(const VariantMatrix& m,
+    non_reference_allele_counts(const AlleleCountMatrix& m,
                                 const std::int8_t refstate);
 
     /*! \brief Count number of non-reference alleles at each site
-     * \param m A VariantMatrix
+     * \param m An AlleleCountMatrix
      * \param m refstate The reference state at each site.
      * \ingroup popgenanalysis
      */
     std::vector<AlleleCounts>
-    non_reference_allele_counts(const VariantMatrix& m,
+    non_reference_allele_counts(const AlleleCountMatrix& m,
                                 const std::vector<std::int8_t>& refstates);
 } // namespace Sequence
 #endif

--- a/Sequence/summstats/classics.hpp
+++ b/Sequence/summstats/classics.hpp
@@ -15,7 +15,7 @@
 namespace Sequence
 {
     /*! \brief Tajima's D
-     * \param m A VariantMatrix
+     * \param m An AlleleCountMatrix
      * \return Tajima's D
      * \note nan is returned if m is empty/invariant.
      *
@@ -26,12 +26,10 @@ namespace Sequence
      *
      * \ingroup popgenanalysis
      */
-    double tajd(const VariantMatrix& m);
-
     double tajd(const AlleleCountMatrix& ac);
 
     /*! The H' statistic
-     * \param m A VariantMatrix
+     * \param m An AlleleCountMatrix
      * \param refstate How the ancestral state is encoded.
      * \return H'
      * \note nan is returned if m is empty/invariant.  It is
@@ -45,11 +43,10 @@ namespace Sequence
      *
      * \ingroup popgenanalysis
      */
-    double hprime(const VariantMatrix& m, const std::int8_t refstate);
     double hprime(const AlleleCountMatrix& ac, const std::int8_t refstate);
 
     /*! The H' statistic
-     * \param m A VariantMatrix
+     * \param m An AlleleCountMatrix
      * \param refstates A vector of ancestral states, equal in length to m.sites
      * \return H'
      * \note nan is returned if m is empty/invariant.  It is
@@ -63,11 +60,11 @@ namespace Sequence
      *
      * \ingroup popgenanalysis
      */
-    double hprime(const VariantMatrix& m,
+    double hprime(const AlleleCountMatrix& m,
                   const std::vector<std::int8_t>& refstates);
 
     /*! \brief Fay and Wu's H.
-     * \param m A VariantMatrix
+     * \param m An AlleleCountMatrix
      * \param refstate The ancestral state.
      * \return Fay and Wu's H, or nan if \a m is empty/invariant.
      *
@@ -81,11 +78,10 @@ namespace Sequence
      * See \cite Fay2000-ef for details.
      * \ingroup popgenanalysis
      */
-    double faywuh(const VariantMatrix& m, const std::int8_t refstate);
-
     double faywuh(const AlleleCountMatrix& ac, const std::int8_t refstate);
+
     /*! \brief Fay and Wu's H.
-     * \param m A VariantMatrix
+     * \param m An AlleleCountMatrix
      * \param refstates The ancestral state at each site.
      * \return Fay and Wu's H, or nan if \a m is empty/invariant.
      *
@@ -99,8 +95,6 @@ namespace Sequence
      * 
      * \ingroup popgenanalysis
      */
-    double faywuh(const VariantMatrix& m,
-                  const std::vector<std::int8_t>& refstates);
     double faywuh(const AlleleCountMatrix& ac,
                   const std::vector<std::int8_t>& refstates);
 

--- a/Sequence/summstats/classics.hpp
+++ b/Sequence/summstats/classics.hpp
@@ -83,6 +83,7 @@ namespace Sequence
      */
     double faywuh(const VariantMatrix& m, const std::int8_t refstate);
 
+    double faywuh(const AlleleCountMatrix& ac, const std::int8_t refstate);
     /*! \brief Fay and Wu's H.
      * \param m A VariantMatrix
      * \param refstates The ancestral state at each site.
@@ -99,6 +100,8 @@ namespace Sequence
      * \ingroup popgenanalysis
      */
     double faywuh(const VariantMatrix& m,
+                  const std::vector<std::int8_t>& refstates);
+    double faywuh(const AlleleCountMatrix& ac,
                   const std::vector<std::int8_t>& refstates);
 
     /*!  \brief Calculate number of differences between all samples.

--- a/Sequence/summstats/classics.hpp
+++ b/Sequence/summstats/classics.hpp
@@ -4,6 +4,7 @@
 #define SEQUENCE_SUMMSTATS_CLASSICS_HPP__
 
 #include <Sequence/VariantMatrix.hpp>
+#include <Sequence/AlleleCountMatrix.hpp>
 
 #include "thetapi.hpp"
 #include "thetaw.hpp"

--- a/Sequence/summstats/classics.hpp
+++ b/Sequence/summstats/classics.hpp
@@ -28,6 +28,9 @@ namespace Sequence
      */
     double tajd(const VariantMatrix& m);
 
+    double
+    tajd(const AlleleCountMatrix& ac);
+
     /*! The H' statistic
      * \param m A VariantMatrix
      * \param refstate How the ancestral state is encoded.

--- a/Sequence/summstats/classics.hpp
+++ b/Sequence/summstats/classics.hpp
@@ -28,8 +28,7 @@ namespace Sequence
      */
     double tajd(const VariantMatrix& m);
 
-    double
-    tajd(const AlleleCountMatrix& ac);
+    double tajd(const AlleleCountMatrix& ac);
 
     /*! The H' statistic
      * \param m A VariantMatrix
@@ -47,6 +46,7 @@ namespace Sequence
      * \ingroup popgenanalysis
      */
     double hprime(const VariantMatrix& m, const std::int8_t refstate);
+    double hprime(const AlleleCountMatrix& ac, const std::int8_t refstate);
 
     /*! The H' statistic
      * \param m A VariantMatrix

--- a/Sequence/summstats/nvariablesites.hpp
+++ b/Sequence/summstats/nvariablesites.hpp
@@ -11,7 +11,7 @@ namespace Sequence
     /*! \brief Number of polymorphic sites
      *
      * Returns the number of sites with more than one non-missing state
-     * \param m An alleleCountMatrix
+     * \param m An AlleleCountMatrix
      * \return std::uint32_t
      * \ingroup popgenanalysis
      */
@@ -20,7 +20,7 @@ namespace Sequence
     /*! \brief Number of bi-allelic sites
      *
      * Return the number of sites with exactly two non-missing states.
-     * \param m An alleleCountMatrix
+     * \param m An AlleleCountMatrix
      * \return std::uint32_t
      * \ingroup popgenanalysis
      */
@@ -32,7 +32,7 @@ namespace Sequence
      * is \f$k_i - 1\f$ if \f$k_i\f$, the number of states at the \f$i^{th}\f$ site,
      * is greater than one, and zero otherwise.
      *
-     * \param m An alleleCountMatrix
+     * \param m An AlleleCountMatrix
      * \return std::uint32_t
      * \ingroup popgenanalysis
      */

--- a/Sequence/summstats/nvariablesites.hpp
+++ b/Sequence/summstats/nvariablesites.hpp
@@ -4,27 +4,27 @@
 #define SEQUENCE_SUMMSTATS_NVARIABLESITES_HPP__
 
 #include <cstdint>
-#include <Sequence/VariantMatrix.hpp>
+#include <Sequence/AlleleCountMatrix.hpp>
 
 namespace Sequence
 {
     /*! \brief Number of polymorphic sites
      *
      * Returns the number of sites with more than one non-missing state
-     * \param m A VariantMatrix
+     * \param m An alleleCountMatrix
      * \return std::uint32_t
      * \ingroup popgenanalysis
      */
-    std::uint32_t nvariable_sites(const VariantMatrix& m);
+    std::uint32_t nvariable_sites(const AlleleCountMatrix& m);
 
     /*! \brief Number of bi-allelic sites
      *
      * Return the number of sites with exactly two non-missing states.
-     * \param m A VariantMatrix
+     * \param m An alleleCountMatrix
      * \return std::uint32_t
      * \ingroup popgenanalysis
      */
-    std::uint32_t nbiallelic_sites(const VariantMatrix& m);
+    std::uint32_t nbiallelic_sites(const AlleleCountMatrix& m);
 
     /*! \brief Total number of mutations in the sample
      *
@@ -32,11 +32,11 @@ namespace Sequence
      * is \f$k_i - 1\f$ if \f$k_i\f$, the number of states at the \f$i^{th}\f$ site,
      * is greater than one, and zero otherwise.
      *
-     * \param m A VariantMatrix
+     * \param m An alleleCountMatrix
      * \return std::uint32_t
      * \ingroup popgenanalysis
      */
-    std::uint32_t total_number_of_mutations(const VariantMatrix& m);
+    std::uint32_t total_number_of_mutations(const AlleleCountMatrix& m);
 } // namespace Sequence
 
 #endif

--- a/Sequence/summstats/thetah.hpp
+++ b/Sequence/summstats/thetah.hpp
@@ -9,14 +9,14 @@
 namespace Sequence
 {
     /*! \brief Fay and Wu's \f$\hat\theta_H\f$.
-     * \param m a VariantMatrix
+     * \param m An AlleleCountMatrix
      * \param refstate The ancestral state
      * \return double
      *
      * See \cite Fay2000-ef for details.
      * \ingroup popgenanalysis
      */
-    double thetah(const VariantMatrix& m, const std::int8_t refstate);
+    double thetah(const AlleleCountMatrix& ac, const std::int8_t refstate);
 
     /*! \brief Fay and Wu's \f$\hat\theta_H\f$.
      * \param m a VariantMatrix
@@ -26,9 +26,6 @@ namespace Sequence
      * See \cite Fay2000-ef for details.
      * \ingroup popgenanalysis
      */
-    double thetah(const VariantMatrix& m,
-                  const std::vector<std::int8_t>& refstates);
-    double thetah(const AlleleCountMatrix& ac, const std::int8_t refstate);
     double thetah(const AlleleCountMatrix& m,
                   const std::vector<std::int8_t>& refstates);
 } // namespace Sequence

--- a/Sequence/summstats/thetah.hpp
+++ b/Sequence/summstats/thetah.hpp
@@ -28,6 +28,9 @@ namespace Sequence
      */
     double thetah(const VariantMatrix& m,
                   const std::vector<std::int8_t>& refstates);
+    double thetah(const AlleleCountMatrix& ac, const std::int8_t refstate);
+    double thetah(const AlleleCountMatrix& m,
+                  const std::vector<std::int8_t>& refstates);
 } // namespace Sequence
 
 #endif

--- a/Sequence/summstats/thetah.hpp
+++ b/Sequence/summstats/thetah.hpp
@@ -4,7 +4,7 @@
 #define SEQUENCE_SUMMSTATS_THETAH_HPP__
 
 #include <vector>
-#include <Sequence/VariantMatrix.hpp>
+#include <Sequence/AlleleCountMatrix.hpp>
 
 namespace Sequence
 {

--- a/Sequence/summstats/thetal.hpp
+++ b/Sequence/summstats/thetal.hpp
@@ -4,7 +4,7 @@
 #define SEQUENCE_SUMMSTATS_THETAL_HPP__
 
 #include <vector>
-#include <Sequence/VariantMatrix.hpp>
+#include <Sequence/AlleleCountMatrix.hpp>
 
 namespace Sequence
 {

--- a/Sequence/summstats/thetal.hpp
+++ b/Sequence/summstats/thetal.hpp
@@ -28,6 +28,9 @@ namespace Sequence
      */
     double thetal(const VariantMatrix& m,
                   const std::vector<std::int8_t>& refstates);
+    double thetal(const AlleleCountMatrix& ac, const std::int8_t refstate);
+    double thetal(const AlleleCountMatrix& m,
+                  const std::vector<std::int8_t>& refstates);
 } // namespace Sequence
 
 #endif

--- a/Sequence/summstats/thetal.hpp
+++ b/Sequence/summstats/thetal.hpp
@@ -9,26 +9,23 @@
 namespace Sequence
 {
     /*! \brief Zeng et al. \f$\hat\theta_L\f$
-     * \param m a VariantMatrix
+     * \param m An AlleleCountMatrix
      * \param refstate The ancestral state
      * \return double
      *
      * See \cite Zeng2006-is for details.
      * \ingroup popgenanalysis
      */
-    double thetal(const VariantMatrix& m, const std::int8_t refstate);
+    double thetal(const AlleleCountMatrix& ac, const std::int8_t refstate);
 
     /*! \brief Zeng et al. \f$\hat\theta_L\f$
-     * \param m a VariantMatrix
+     * \param m An AlleleCountMatrix
      * \param refstate Vector of ancestral states.
      * \return double
      *
      * See \cite Zeng2006-is for details.
      * \ingroup popgenanalysis
      */
-    double thetal(const VariantMatrix& m,
-                  const std::vector<std::int8_t>& refstates);
-    double thetal(const AlleleCountMatrix& ac, const std::int8_t refstate);
     double thetal(const AlleleCountMatrix& m,
                   const std::vector<std::int8_t>& refstates);
 } // namespace Sequence

--- a/Sequence/summstats/thetapi.hpp
+++ b/Sequence/summstats/thetapi.hpp
@@ -4,7 +4,7 @@
 #ifndef SEQUENCE_SUMMSTATS_THETAPI_HPP__
 #define SEQUENCE_SUMMSTATS_THETAPI_HPP__
 
-#include <Sequence/VariantMatrix.hpp>
+#include <Sequence/AlleleCountMatrix.hpp>
 
 namespace Sequence
 {

--- a/Sequence/summstats/thetapi.hpp
+++ b/Sequence/summstats/thetapi.hpp
@@ -21,6 +21,9 @@ namespace Sequence
      * \ingroup popgenanalysis
      */
     double thetapi(const VariantMatrix& m);
+
+    double
+    thetapi(const AlleleCountMatrix& ac);
 } // namespace Sequence
 
 #endif

--- a/Sequence/summstats/thetapi.hpp
+++ b/Sequence/summstats/thetapi.hpp
@@ -9,7 +9,7 @@
 namespace Sequence
 {
     /*! \brief Mean pairwise differences
-     * \param m A VariantMatrix
+     * \param m An AlleleCountMatrix
      * \return Mean pairwise differences
      * \note Calcuated as sum over one minus site homozygosity
      *
@@ -20,10 +20,7 @@ namespace Sequence
      * See \cite Tajima1983-it for details.
      * \ingroup popgenanalysis
      */
-    double thetapi(const VariantMatrix& m);
-
-    double
-    thetapi(const AlleleCountMatrix& ac);
+    double thetapi(const AlleleCountMatrix& ac);
 } // namespace Sequence
 
 #endif

--- a/Sequence/summstats/thetaw.hpp
+++ b/Sequence/summstats/thetaw.hpp
@@ -8,7 +8,7 @@
 namespace Sequence
 {
     /*! \brief Watterson's theta
-     * \param m A Variant matrix
+     * \param m An AlleleCountMatrix
      * \returns Watterson's theta, a double
      * 
      * \note For a site with \f$k\f$ states,
@@ -19,7 +19,6 @@ namespace Sequence
      * See \cite Watterson1975-ej for details.
      * \ingroup popgenanalysis
      */
-    double thetaw(const VariantMatrix& m);
     double thetaw(const AlleleCountMatrix& ac);
 } // namespace Sequence
 

--- a/Sequence/summstats/thetaw.hpp
+++ b/Sequence/summstats/thetaw.hpp
@@ -3,7 +3,7 @@
 #ifndef SEQUENCE_SUMMSTATS_THETAW_HPP__
 #define SEQUENCE_SUMMSTATS_THETAW_HPP__
 
-#include <Sequence/VariantMatrix.hpp>
+#include <Sequence/AlleleCountMatrix.hpp>
 
 namespace Sequence
 {

--- a/Sequence/summstats/thetaw.hpp
+++ b/Sequence/summstats/thetaw.hpp
@@ -19,7 +19,8 @@ namespace Sequence
      * See \cite Watterson1975-ej for details.
      * \ingroup popgenanalysis
      */
-    double thetaw(const VariantMatrix &m);
+    double thetaw(const VariantMatrix& m);
+    double thetaw(const AlleleCountMatrix& ac);
 } // namespace Sequence
 
 #endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -45,6 +45,7 @@ libsequence_la_SOURCES=  Grantham.cc\
 	SummStats/lHaf.cc \
 	variant_matrix/VariantMatrix.cc \
 	variant_matrix/VariantMatrixViews.cc \
+	variant_matrix/AlleleCountMatrix.cc \
 	variant_matrix/StateCounts.cc \
 	variant_matrix/filtering.cc \
 	summstats/thetapi.cc \

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -148,6 +148,7 @@ am_libsequence_la_OBJECTS = Grantham.lo PathwayHelper.lo \
 	SummStats/Garud.lo SeqAlphabets.lo SummStats/lHaf.lo \
 	variant_matrix/VariantMatrix.lo \
 	variant_matrix/VariantMatrixViews.lo \
+	variant_matrix/AlleleCountMatrix.lo \
 	variant_matrix/StateCounts.lo variant_matrix/filtering.lo \
 	summstats/thetapi.lo summstats/thetaw.lo summstats/tajd.lo \
 	summstats/thetah_thetal.lo summstats/faywuh.lo \
@@ -393,6 +394,7 @@ libsequence_la_SOURCES = Grantham.cc\
 	SummStats/lHaf.cc \
 	variant_matrix/VariantMatrix.cc \
 	variant_matrix/VariantMatrixViews.cc \
+	variant_matrix/AlleleCountMatrix.cc \
 	variant_matrix/StateCounts.cc \
 	variant_matrix/filtering.cc \
 	summstats/thetapi.cc \
@@ -525,6 +527,8 @@ variant_matrix/$(DEPDIR)/$(am__dirstamp):
 variant_matrix/VariantMatrix.lo: variant_matrix/$(am__dirstamp) \
 	variant_matrix/$(DEPDIR)/$(am__dirstamp)
 variant_matrix/VariantMatrixViews.lo: variant_matrix/$(am__dirstamp) \
+	variant_matrix/$(DEPDIR)/$(am__dirstamp)
+variant_matrix/AlleleCountMatrix.lo: variant_matrix/$(am__dirstamp) \
 	variant_matrix/$(DEPDIR)/$(am__dirstamp)
 variant_matrix/StateCounts.lo: variant_matrix/$(am__dirstamp) \
 	variant_matrix/$(DEPDIR)/$(am__dirstamp)
@@ -693,6 +697,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@summstats/$(DEPDIR)/thetah_thetal.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@summstats/$(DEPDIR)/thetapi.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@summstats/$(DEPDIR)/thetaw.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@variant_matrix/$(DEPDIR)/AlleleCountMatrix.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@variant_matrix/$(DEPDIR)/StateCounts.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@variant_matrix/$(DEPDIR)/VariantMatrix.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@variant_matrix/$(DEPDIR)/VariantMatrixViews.Plo@am__quote@

--- a/src/summstats/allele_counts.cc
+++ b/src/summstats/allele_counts.cc
@@ -24,7 +24,7 @@ namespace
                 throw std::invalid_argument("reference state out of range");
             }
         typename count_type::value_type rv{ 0, 0 };
-        unsigned nnon_missing = 0;
+        int nnon_missing = 0;
         for (auto i = row.first; i != row.second; ++i)
             {
                 if (*i > 0)
@@ -39,7 +39,7 @@ namespace
                             }
                     }
             }
-        rv.nmissing = nsam - nnon_missing;
+        rv.nmissing = static_cast<int>(nsam) - nnon_missing;
         return rv;
     }
 } // namespace

--- a/src/summstats/allele_counts.cc
+++ b/src/summstats/allele_counts.cc
@@ -2,35 +2,44 @@
 #include <utility>
 #include <cstdint>
 #include <Sequence/summstats/allele_counts.hpp>
-#include <Sequence/StateCounts.hpp>
-#include <Sequence/VariantMatrix.hpp>
-#include <Sequence/VariantMatrixViews.hpp>
+#include <Sequence/AlleleCountMatrix.hpp>
 
 using count_type = std::vector<Sequence::AlleleCounts>;
 
 namespace
 {
+    template <typename T>
     typename count_type::value_type
-    add_counts(const Sequence::StateCounts& counts, const std::size_t nsam,
-               const bool nonref)
+    add_counts(const T& row, const std::size_t nsam, const bool nonref,
+               const std::int8_t refstate)
     {
-        if (nonref && counts.refstate == -1)
+        if (nonref && refstate == -1)
             {
                 return count_type::value_type{ -1, -1 };
             }
-        typename count_type::value_type rv{ 0, 0 };
-        rv.nmissing = nsam - counts.n;
-        for (std::size_t i = 0; i < counts.counts.size(); ++i)
+        std::size_t refindex = static_cast<std::size_t>(refstate);
+        if (nonref
+            && refindex >= static_cast<std::size_t>(row.second - row.first))
             {
-                if (counts.counts[i] > 0)
+                throw std::invalid_argument("reference state out of range");
+            }
+        typename count_type::value_type rv{ 0, 0 };
+        unsigned nnon_missing = 0;
+        for (auto i = row.first; i != row.second; ++i)
+            {
+                if (*i > 0)
                     {
+                        nnon_missing += *i;
                         if (!nonref
-                            || (nonref && counts.counts[i] != counts.refstate))
+                            || (nonref
+                                && static_cast<std::size_t>(i - row.first)
+                                       != refindex))
                             {
                                 ++rv.nstates;
                             }
                     }
             }
+        rv.nmissing = nsam - nnon_missing;
         return rv;
     }
 } // namespace
@@ -38,51 +47,44 @@ namespace
 namespace Sequence
 {
     count_type
-    allele_counts(const VariantMatrix& m)
+    allele_counts(const AlleleCountMatrix& m)
     {
         count_type rv;
-        StateCounts counts;
-        for (std::size_t i = 0; i < m.nsites; ++i)
+        for (std::size_t i = 0; i < m.nrow; ++i)
             {
-                auto r = get_ConstRowView(m, i);
-                counts(r);
-                rv.emplace_back(add_counts(counts, m.nsam, false));
+                auto r = m.row(i);
+                rv.emplace_back(add_counts(r, m.nsam, false, -1));
             }
         return rv;
     }
 
     count_type
-    non_reference_allele_counts(const VariantMatrix& m,
+    non_reference_allele_counts(const AlleleCountMatrix& m,
                                 const std::vector<std::int8_t>& refstates)
     {
-        if (refstates.size() != m.nsites)
+        if (refstates.size() != m.nrow)
             {
                 throw std::invalid_argument("number of reference states does "
                                             "not equal number of sites");
             }
         count_type rv;
-        StateCounts counts;
-        for (std::size_t i = 0; i < m.nsites; ++i)
+        for (std::size_t i = 0; i < m.nrow; ++i)
             {
-                counts.refstate = refstates[i];
-                auto r = get_ConstRowView(m, i);
-                counts(r);
-                rv.emplace_back(add_counts(counts, m.nsam, true));
+                auto r = m.row(i);
+                rv.emplace_back(add_counts(r, m.nsam, true, refstates[i]));
             }
         return rv;
     }
 
     count_type
-    non_reference_allele_counts(const VariantMatrix& m,
+    non_reference_allele_counts(const AlleleCountMatrix& m,
                                 const std::int8_t refstate)
     {
         count_type rv;
-        StateCounts counts(refstate);
-        for (std::size_t i = 0; i < m.nsites; ++i)
+        for (std::size_t i = 0; i < m.nrow; ++i)
             {
-                auto r = get_ConstRowView(m, i);
-                counts(r);
-                rv.emplace_back(add_counts(counts, m.nsam, true));
+                auto r = m.row(i);
+                rv.emplace_back(add_counts(r, m.nsam, true, refstate));
             }
         return rv;
     }

--- a/src/summstats/faywuh.cc
+++ b/src/summstats/faywuh.cc
@@ -1,32 +1,9 @@
 #include <functional>
-#include <Sequence/summstats/algorithm.hpp>
+#include <Sequence/AlleleCountMatrix.hpp>
 #include "hprime_faywuh_aggregator.hpp"
 
 namespace Sequence
 {
-    double
-    faywuh(const VariantMatrix& m, const std::int8_t refstate)
-    {
-        detail::hprime_faywuh_aggregator agg(2.0);
-        sstats_algo::aggregate_sites(m, std::ref(agg), refstate);
-        if (agg.pi == 0.0)
-            {
-                return std::numeric_limits<double>::quiet_NaN();
-            }
-        return agg.pi - agg.theta;
-    }
-
-    double
-    faywuh(const VariantMatrix& m, const std::vector<std::int8_t>& refstates)
-    {
-        detail::hprime_faywuh_aggregator agg(2.0);
-        sstats_algo::aggregate_sites(m, std::ref(agg), refstates);
-        if (agg.pi == 0.0)
-            {
-                return std::numeric_limits<double>::quiet_NaN();
-            }
-        return agg.pi - agg.theta;
-    }
     double
     faywuh(const AlleleCountMatrix& ac, const std::int8_t refstate)
     {

--- a/src/summstats/faywuh.cc
+++ b/src/summstats/faywuh.cc
@@ -8,13 +8,13 @@ namespace Sequence
     faywuh(const AlleleCountMatrix& ac, const std::int8_t refstate)
     {
         auto refindex = static_cast<std::size_t>(refstate);
-        if (refindex >= ac.row_size)
+        if (refindex >= ac.ncol)
             {
                 throw std::invalid_argument(
                     "reference state greater than max allelic state");
             }
         detail::hprime_faywuh_row_processor rp(2.0);
-        for (std::size_t i = 0; i < ac.counts.size(); i += ac.row_size)
+        for (std::size_t i = 0; i < ac.counts.size(); i += ac.ncol)
             {
                 rp(ac, i, refindex);
             }
@@ -33,7 +33,7 @@ namespace Sequence
             {
                 return std::numeric_limits<double>::quiet_NaN();
             }
-        if (refstates.size() != ac.counts.size() / ac.row_size)
+        if (refstates.size() != ac.counts.size() / ac.ncol)
             {
                 throw std::invalid_argument(
                     "incorrect number of reference states");
@@ -48,13 +48,13 @@ namespace Sequence
         detail::hprime_faywuh_row_processor rp(2.0);
         std::size_t rstate = 0;
         for (std::size_t i = 0; i < ac.counts.size();
-             i += ac.row_size, ++rstate)
+             i += ac.ncol, ++rstate)
             {
                 if (refstates[rstate] >= 0)
                     {
                         auto refindex
                             = static_cast<std::size_t>(refstates[rstate]);
-                        if (refindex >= ac.row_size)
+                        if (refindex >= ac.ncol)
                             {
                                 throw std::invalid_argument(
                                     "reference state greater than max allelic "

--- a/src/summstats/faywuh.cc
+++ b/src/summstats/faywuh.cc
@@ -7,6 +7,10 @@ namespace Sequence
     double
     faywuh(const AlleleCountMatrix& ac, const std::int8_t refstate)
     {
+        if (ac.counts.empty())
+            {
+                return std::numeric_limits<double>::quiet_NaN();
+            }
         auto refindex = static_cast<std::size_t>(refstate);
         if (refindex >= ac.ncol)
             {

--- a/src/summstats/faywuh.cc
+++ b/src/summstats/faywuh.cc
@@ -27,4 +27,69 @@ namespace Sequence
             }
         return agg.pi - agg.theta;
     }
+    double
+    faywuh(const AlleleCountMatrix& ac, const std::int8_t refstate)
+    {
+        auto refindex = static_cast<std::size_t>(refstate);
+        if (refindex >= ac.row_size)
+            {
+                throw std::invalid_argument(
+                    "reference state greater than max allelic state");
+            }
+        detail::hprime_faywuh_row_processor rp(2.0);
+        for (std::size_t i = 0; i < ac.counts.size(); i += ac.row_size)
+            {
+                rp(ac, i, refindex);
+            }
+        if (!rp.S)
+            {
+                return std::numeric_limits<double>::quiet_NaN();
+            }
+        return rp.pi - rp.theta;
+    }
+
+    double
+    faywuh(const AlleleCountMatrix& ac,
+           const std::vector<std::int8_t>& refstates)
+    {
+        if (ac.counts.empty())
+            {
+                return std::numeric_limits<double>::quiet_NaN();
+            }
+        if (refstates.size() != ac.counts.size() / ac.row_size)
+            {
+                throw std::invalid_argument(
+                    "incorrect number of reference states");
+            }
+        if (std::all_of(refstates.begin(), refstates.end(),
+                        [](const std::int8_t i) { return i < 0; }))
+            {
+                throw std::invalid_argument(
+                    "all reference states encoded as missing");
+            }
+
+        detail::hprime_faywuh_row_processor rp(2.0);
+        std::size_t rstate = 0;
+        for (std::size_t i = 0; i < ac.counts.size();
+             i += ac.row_size, ++rstate)
+            {
+                if (refstates[rstate] >= 0)
+                    {
+                        auto refindex
+                            = static_cast<std::size_t>(refstates[rstate]);
+                        if (refindex >= ac.row_size)
+                            {
+                                throw std::invalid_argument(
+                                    "reference state greater than max allelic "
+                                    "state");
+                            }
+                        rp(ac, i, refindex);
+                    }
+            }
+        if (!rp.S)
+            {
+                return std::numeric_limits<double>::quiet_NaN();
+            }
+        return rp.pi - rp.theta;
+    }
 } // namespace Sequence

--- a/src/summstats/hprime.cc
+++ b/src/summstats/hprime.cc
@@ -1,12 +1,8 @@
 #include <cmath>
 #include <functional>
-#include <Sequence/summstats/algorithm.hpp>
-#include "hprime_faywuh_aggregator.hpp"
-#include <Sequence/VariantMatrix.hpp>
-#include <Sequence/VariantMatrixViews.hpp>
+#include <Sequence/AlleleCountMatrix.hpp>
 #include <Sequence/summstats/auxillary.hpp>
-#include <Sequence/summstats/thetapi.hpp>
-#include <Sequence/summstats/thetal.hpp>
+#include "hprime_faywuh_aggregator.hpp"
 
 namespace
 {
@@ -45,22 +41,6 @@ namespace
 
 namespace Sequence
 {
-    double
-    hprime(const VariantMatrix &m, const std::int8_t refstate)
-    {
-        detail::hprime_faywuh_aggregator hp(1.0);
-        sstats_algo::aggregate_sites(m, std::ref(hp), refstate);
-        return hprime_common(m.nsam, hp.S, hp.pi, hp.theta);
-    }
-
-    double
-    hprime(const VariantMatrix &m, const std::vector<std::int8_t> &refstates)
-    {
-        detail::hprime_faywuh_aggregator hp(1.0);
-        sstats_algo::aggregate_sites(m, std::ref(hp), refstates);
-        return hprime_common(m.nsam, hp.S, hp.pi, hp.theta);
-    }
-
     double
     hprime(const AlleleCountMatrix &ac, const std::int8_t refstate)
     {

--- a/src/summstats/hprime.cc
+++ b/src/summstats/hprime.cc
@@ -45,13 +45,13 @@ namespace Sequence
     hprime(const AlleleCountMatrix &ac, const std::int8_t refstate)
     {
         auto refindex = static_cast<std::size_t>(refstate);
-        if (refindex >= ac.row_size)
+        if (refindex >= ac.ncol)
             {
                 throw std::invalid_argument(
                     "reference state greater than max allelic state");
             }
         detail::hprime_faywuh_row_processor rp(1.0);
-        for (std::size_t i = 0; i < ac.counts.size(); i += ac.row_size)
+        for (std::size_t i = 0; i < ac.counts.size(); i += ac.ncol)
             {
                 rp(ac, i, refindex);
             }
@@ -66,7 +66,7 @@ namespace Sequence
             {
                 return std::numeric_limits<double>::quiet_NaN();
             }
-        if (refstates.size() != ac.counts.size() / ac.row_size)
+        if (refstates.size() != ac.counts.size() / ac.ncol)
             {
                 throw std::invalid_argument(
                     "incorrect number of reference states");
@@ -81,13 +81,13 @@ namespace Sequence
         detail::hprime_faywuh_row_processor rp(1.0);
         std::size_t rstate = 0;
         for (std::size_t i = 0; i < ac.counts.size();
-             i += ac.row_size, ++rstate)
+             i += ac.ncol, ++rstate)
             {
                 if (refstates[rstate] >= 0)
                     {
                         auto refindex
                             = static_cast<std::size_t>(refstates[rstate]);
-                        if (refindex >= ac.row_size)
+                        if (refindex >= ac.ncol)
                             {
                                 throw std::invalid_argument(
                                     "reference state greater than max allelic "

--- a/src/summstats/hprime.cc
+++ b/src/summstats/hprime.cc
@@ -44,6 +44,10 @@ namespace Sequence
     double
     hprime(const AlleleCountMatrix &ac, const std::int8_t refstate)
     {
+        if (ac.counts.empty())
+            {
+                return std::numeric_limits<double>::quiet_NaN();
+            }
         auto refindex = static_cast<std::size_t>(refstate);
         if (refindex >= ac.ncol)
             {

--- a/src/summstats/hprime.cc
+++ b/src/summstats/hprime.cc
@@ -59,7 +59,8 @@ namespace Sequence
             {
                 rp(ac, i, refindex);
             }
-        return hprime_common(ac.nsam, rp.S, rp.pi, rp.theta);
+        return hprime_common(static_cast<std::uint32_t>(ac.nsam), rp.S, rp.pi,
+                             rp.theta);
     }
 
     double
@@ -84,8 +85,7 @@ namespace Sequence
 
         detail::hprime_faywuh_row_processor rp(1.0);
         std::size_t rstate = 0;
-        for (std::size_t i = 0; i < ac.counts.size();
-             i += ac.ncol, ++rstate)
+        for (std::size_t i = 0; i < ac.counts.size(); i += ac.ncol, ++rstate)
             {
                 if (refstates[rstate] >= 0)
                     {
@@ -100,6 +100,7 @@ namespace Sequence
                         rp(ac, i, refindex);
                     }
             }
-        return hprime_common(ac.nsam, rp.S, rp.pi, rp.theta);
+        return hprime_common(static_cast<std::uint32_t>(ac.nsam), rp.S, rp.pi,
+                             rp.theta);
     }
 } // namespace Sequence

--- a/src/summstats/hprime_faywuh_aggregator.hpp
+++ b/src/summstats/hprime_faywuh_aggregator.hpp
@@ -8,6 +8,62 @@ namespace Sequence
 {
     namespace detail
     {
+        struct hprime_faywuh_row_processor
+        {
+            unsigned S;
+            double pi, theta;
+            const double power;
+            hprime_faywuh_row_processor(const double p)
+                : S{ 0 }, pi{ 0.0 }, theta{ 0.0 }, power{ p }
+            {
+            }
+
+            inline void
+            operator()(const Sequence::AlleleCountMatrix &ac, const std::size_t i,
+                       const std::size_t refindex)
+            {
+                unsigned nstates = 0;
+                bool refseen = false;
+                double temp = 0.0;
+                double homozygosity = 0.0;
+                for (std::size_t j = i; j < i + ac.row_size; ++j)
+                    {
+                        auto ci = ac.counts[j];
+                        if (ci > 0)
+                            {
+                                homozygosity
+                                    += static_cast<double>(ci * (ci - 1));
+                                ++nstates;
+                                if (j - i != refindex)
+                                    {
+                                        temp += std::pow(
+                                            static_cast<double>(ci), power);
+                                    }
+                                else
+                                    {
+                                        refseen = true;
+                                    }
+                            }
+                    }
+                if (nstates > 2)
+                    {
+                        throw std::runtime_error(
+                            "site has more than one derived state");
+                    }
+
+                if (nstates > 1)
+                    {
+                        ++S;
+                    }
+                if (refseen)
+                    {
+                        double nnm1 = static_cast<double>(ac.nsam * (ac.nsam - 1));
+                        pi += 1.0 - homozygosity / nnm1;
+                        theta += temp / nnm1;
+                    }
+            }
+        };
+
         struct hprime_faywuh_aggregator
         {
             unsigned S;

--- a/src/summstats/hprime_faywuh_aggregator.hpp
+++ b/src/summstats/hprime_faywuh_aggregator.hpp
@@ -26,7 +26,7 @@ namespace Sequence
                 bool refseen = false;
                 double temp = 0.0;
                 double homozygosity = 0.0;
-                for (std::size_t j = i; j < i + ac.row_size; ++j)
+                for (std::size_t j = i; j < i + ac.ncol; ++j)
                     {
                         auto ci = ac.counts[j];
                         if (ci > 0)

--- a/src/summstats/hprime_faywuh_aggregator.hpp
+++ b/src/summstats/hprime_faywuh_aggregator.hpp
@@ -2,7 +2,6 @@
 #define SEQUENCE_DETAIL_HPRIME_FAYWUH_AGGREGATOR_HPP
 
 #include <cmath>
-#include <Sequence/StateCounts.hpp>
 
 namespace Sequence
 {
@@ -19,8 +18,8 @@ namespace Sequence
             }
 
             inline void
-            operator()(const Sequence::AlleleCountMatrix &ac, const std::size_t i,
-                       const std::size_t refindex)
+            operator()(const Sequence::AlleleCountMatrix &ac,
+                       const std::size_t i, const std::size_t refindex)
             {
                 unsigned nstates = 0;
                 bool refseen = false;
@@ -57,62 +56,8 @@ namespace Sequence
                     }
                 if (refseen)
                     {
-                        double nnm1 = static_cast<double>(ac.nsam * (ac.nsam - 1));
-                        pi += 1.0 - homozygosity / nnm1;
-                        theta += temp / nnm1;
-                    }
-            }
-        };
-
-        struct hprime_faywuh_aggregator
-        {
-            unsigned S;
-            double pi, theta;
-            const double power;
-            hprime_faywuh_aggregator(const double p)
-                : S{ 0 }, pi{ 0.0 }, theta{ 0.0 }, power{ p }
-            {
-            }
-
-            inline void
-            operator()(const Sequence::StateCounts &c)
-            {
-                unsigned nstates = 0;
-                bool refseen = false;
-                double temp = 0.0;
-                double homozygosity = 0.0;
-                for (std::size_t i = 0; i < c.counts.size(); ++i)
-                    {
-                        auto ci = c.counts[i];
-                        if (ci > 0)
-                            {
-                                homozygosity
-                                    += static_cast<double>(ci * (ci - 1));
-                                ++nstates;
-                                if (static_cast<std::int8_t>(i) != c.refstate)
-                                    {
-                                        temp += std::pow(
-                                            static_cast<double>(ci), power);
-                                    }
-                                else
-                                    {
-                                        refseen = true;
-                                    }
-                            }
-                    }
-                if (nstates > 2)
-                    {
-                        throw std::runtime_error(
-                            "site has more than one derived state");
-                    }
-
-                if (nstates > 1)
-                    {
-                        ++S;
-                    }
-                if (refseen)
-                    {
-                        double nnm1 = static_cast<double>(c.n * (c.n - 1));
+                        double nnm1
+                            = static_cast<double>(ac.nsam * (ac.nsam - 1));
                         pi += 1.0 - homozygosity / nnm1;
                         theta += temp / nnm1;
                     }

--- a/src/summstats/nvariablesites.cc
+++ b/src/summstats/nvariablesites.cc
@@ -1,23 +1,21 @@
 #include <cstdint>
 #include <algorithm>
-#include <Sequence/StateCounts.hpp>
-#include <Sequence/VariantMatrix.hpp>
-#include <Sequence/VariantMatrixViews.hpp>
+#include <Sequence/AlleleCountMatrix.hpp>
 
 namespace Sequence
 {
     std::uint32_t
-    nvariable_sites(const VariantMatrix& m)
+    nvariable_sites(const AlleleCountMatrix& m)
     {
         std::uint32_t nv = 0;
-        StateCounts counts;
-        for (std::size_t site = 0; site < m.nsites; ++site)
+        for (std::size_t site = 0; site < m.nrow; ++site)
             {
-                auto site_view = get_RowView(m, site);
-                counts(site_view);
-                auto nstates = std::count_if(
-                    counts.counts.begin(), counts.counts.end(),
-                    [](const std::int32_t x) { return x > 0; });
+                auto r = m.row(site);
+                auto nstates
+                    = std::count_if(r.first, r.second,
+                                    [](const AlleleCountMatrix::value_type c) {
+                                        return c > 0;
+                                    });
                 if (nstates > 1)
                     {
                         ++nv;
@@ -27,18 +25,17 @@ namespace Sequence
     }
 
     std::uint32_t
-    nbiallelic_sites(const VariantMatrix& m)
+    nbiallelic_sites(const AlleleCountMatrix& m)
     {
         std::uint32_t nv = 0;
-        StateCounts counts;
-        for (std::size_t site = 0; site < m.nsites; ++site)
+        for (std::size_t site = 0; site < m.nrow; ++site)
             {
-                auto site_view = get_RowView(m, site);
-                counts(site_view);
-
-                auto nstates = std::count_if(
-                    counts.counts.begin(), counts.counts.end(),
-                    [](const std::int32_t x) { return x > 0; });
+                auto r = m.row(site);
+                auto nstates
+                    = std::count_if(r.first, r.second,
+                                    [](const AlleleCountMatrix::value_type c) {
+                                        return c > 0;
+                                    });
                 if (nstates == 2)
                     {
                         ++nv;
@@ -48,18 +45,17 @@ namespace Sequence
     }
 
     std::uint32_t
-    total_number_of_mutations(const VariantMatrix& m)
+    total_number_of_mutations(const AlleleCountMatrix& m)
     {
         std::uint32_t nv = 0;
-        StateCounts counts;
-        for (std::size_t site = 0; site < m.nsites; ++site)
+        for (std::size_t site = 0; site < m.nrow; ++site)
             {
-                auto site_view = get_RowView(m, site);
-                counts(site_view);
-
-                auto nstates = std::count_if(
-                    counts.counts.begin(), counts.counts.end(),
-                    [](const std::int32_t x) { return x > 0; });
+                auto r = m.row(site);
+                auto nstates
+                    = std::count_if(r.first, r.second,
+                                    [](const AlleleCountMatrix::value_type c) {
+                                        return c > 0;
+                                    });
                 if (nstates > 1)
                     {
                         nv += static_cast<decltype(nv)>(nstates) - 1;

--- a/src/summstats/rmin.cc
+++ b/src/summstats/rmin.cc
@@ -2,6 +2,7 @@
 #include <Sequence/summstats/ld.hpp>
 #include <Sequence/summstats/allele_counts.hpp>
 #include <Sequence/VariantMatrix.hpp>
+#include <Sequence/AlleleCountMatrix.hpp>
 #include <Sequence/VariantMatrixViews.hpp>
 
 namespace Sequence
@@ -13,7 +14,8 @@ namespace Sequence
             {
                 return -1;
             }
-        auto ac = allele_counts(m);
+        Sequence::AlleleCountMatrix acm(m);
+        auto ac = allele_counts(acm);
         std::vector<std::size_t> biallelic_site_indexes;
         for (std::size_t i = 0; i < ac.size(); ++i)
             {

--- a/src/summstats/tajd.cc
+++ b/src/summstats/tajd.cc
@@ -11,12 +11,12 @@ namespace Sequence
         double pi = 0.0;
         int S = 0;
         std::int32_t max_nsam = 0;
-        for (std::size_t i = 0; i < ac.counts.size(); i += ac.row_size)
+        for (std::size_t i = 0; i < ac.counts.size(); i += ac.ncol)
             {
                 std::int32_t nsam = 0;
                 double homozygosity = 0.0;
                 int nstates = 0;
-                for (std::size_t j = i; j < i + ac.row_size; ++j)
+                for (std::size_t j = i; j < i + ac.ncol; ++j)
                     {
                         if (ac.counts[j] > 0)
                             {

--- a/src/summstats/tajd.cc
+++ b/src/summstats/tajd.cc
@@ -1,57 +1,11 @@
 #include <cmath>
 #include <limits>
 #include <Sequence/summstats/algorithm.hpp>
-#include <Sequence/StateCounts.hpp>
 #include <Sequence/VariantMatrixViews.hpp>
 #include <Sequence/summstats/auxillary.hpp>
 
 namespace Sequence
 {
-    double
-    tajd(const VariantMatrix& m)
-    {
-        unsigned S = 0;
-        double pi = 0.0;
-        const auto agg = [&S, &pi](const StateCounts& c) {
-            unsigned nstates = 0;
-            double homozygosity = 0.0;
-            for (std::size_t i = 0; i < c.max_allele_idx + 1; ++i)
-                {
-                    if (c.counts[i])
-                        {
-                            nstates++;
-                            homozygosity
-                                += static_cast<double>(c.counts[i])
-                                   * static_cast<double>(c.counts[i] - 1);
-                        }
-                }
-            if (nstates > 1)
-                {
-                    S += nstates - 1;
-                    double d = static_cast<double>(c.n * (c.n - 1));
-                    pi += (1.0 - homozygosity / d);
-                }
-        };
-        sstats_algo::aggregate_sites(m, agg, -1);
-        if (!S)
-            {
-                return std::numeric_limits<double>::quiet_NaN();
-            }
-        auto a1 = summstats_aux::a_sub_n(static_cast<std::uint32_t>(m.nsam));
-        double w = static_cast<double>(S) / a1;
-        auto a2 = summstats_aux::b_sub_n(static_cast<std::uint32_t>(m.nsam));
-        auto dn = static_cast<double>(m.nsam);
-        double b1 = (dn + 1.0) / (3.0 * (dn - 1.0));
-        double b2
-            = (2.0 * (std::pow(dn, 2.0) + dn + 3.0)) / (9.0 * dn * (dn - 1.0));
-        double c1 = b1 - 1.0 / a1;
-        double c2 = b2 - (dn + 2.0) / (a1 * dn) + a2 / std::pow(a1, 2.0);
-        double e1 = c1 / a1;
-        double e2 = c2 / (std::pow(a1, 2.0) + a2);
-        double denominator = std::pow((e1 * S + e2 * S * (S - 1.0)), 0.5);
-        return (pi - w) / denominator;
-    }
-
     double
     tajd(const AlleleCountMatrix& ac)
     {

--- a/src/summstats/tajd.cc
+++ b/src/summstats/tajd.cc
@@ -1,7 +1,6 @@
 #include <cmath>
 #include <limits>
-#include <Sequence/summstats/algorithm.hpp>
-#include <Sequence/VariantMatrixViews.hpp>
+#include <Sequence/AlleleCountMatrix.hpp>
 #include <Sequence/summstats/auxillary.hpp>
 
 namespace Sequence

--- a/src/summstats/tajd.cc
+++ b/src/summstats/tajd.cc
@@ -15,13 +15,14 @@ namespace Sequence
         const auto agg = [&S, &pi](const StateCounts& c) {
             unsigned nstates = 0;
             double homozygosity = 0.0;
-            for (auto i : c.counts)
+            for (std::size_t i = 0; i < c.max_allele_idx + 1; ++i)
                 {
-                    if (i)
+                    if (c.counts[i])
                         {
                             nstates++;
-                            homozygosity += static_cast<double>(i)
-                                            * static_cast<double>(i - 1);
+                            homozygosity
+                                += static_cast<double>(c.counts[i])
+                                   * static_cast<double>(c.counts[i] - 1);
                         }
                 }
             if (nstates > 1)
@@ -40,6 +41,56 @@ namespace Sequence
         double w = static_cast<double>(S) / a1;
         auto a2 = summstats_aux::b_sub_n(static_cast<std::uint32_t>(m.nsam));
         auto dn = static_cast<double>(m.nsam);
+        double b1 = (dn + 1.0) / (3.0 * (dn - 1.0));
+        double b2
+            = (2.0 * (std::pow(dn, 2.0) + dn + 3.0)) / (9.0 * dn * (dn - 1.0));
+        double c1 = b1 - 1.0 / a1;
+        double c2 = b2 - (dn + 2.0) / (a1 * dn) + a2 / std::pow(a1, 2.0);
+        double e1 = c1 / a1;
+        double e2 = c2 / (std::pow(a1, 2.0) + a2);
+        double denominator = std::pow((e1 * S + e2 * S * (S - 1.0)), 0.5);
+        return (pi - w) / denominator;
+    }
+
+    double
+    tajd(const AlleleCountMatrix& ac)
+    {
+        double pi = 0.0;
+        int S = 0;
+        std::int32_t max_nsam = 0;
+        for (std::size_t i = 0; i < ac.counts.size(); i += ac.row_size)
+            {
+                std::int32_t nsam = 0;
+                double homozygosity = 0.0;
+                int nstates = 0;
+                for (std::size_t j = i; j < i + ac.row_size; ++j)
+                    {
+                        if (ac.counts[j] > 0)
+                            {
+                                ++nstates;
+                                nsam += ac.counts[j];
+                                homozygosity += static_cast<double>(
+                                    ac.counts[j] * (ac.counts[j] - 1));
+                            }
+                    }
+
+                if (nstates)
+                    {
+                        max_nsam = std::max(max_nsam, nsam);
+                        S += nstates - 1;
+                        pi += 1.0
+                              - homozygosity
+                                    / static_cast<double>(nsam * (nsam - 1));
+                    }
+            }
+        if (!S)
+            {
+                return std::numeric_limits<double>::quiet_NaN();
+            }
+        auto a1 = summstats_aux::a_sub_n(static_cast<std::uint32_t>(max_nsam));
+        double w = static_cast<double>(S) / a1;
+        auto a2 = summstats_aux::b_sub_n(static_cast<std::uint32_t>(max_nsam));
+        auto dn = static_cast<double>(max_nsam);
         double b1 = (dn + 1.0) / (3.0 * (dn - 1.0));
         double b2
             = (2.0 * (std::pow(dn, 2.0) + dn + 3.0)) / (9.0 * dn * (dn - 1.0));

--- a/src/summstats/thetah_thetal.cc
+++ b/src/summstats/thetah_thetal.cc
@@ -16,7 +16,7 @@ namespace
         std::int32_t nnonref = 0;
         double temp = 0.0;
         bool ref_seen = false;
-        for (std::size_t j = i; j < i + ac.row_size; ++j)
+        for (std::size_t j = i; j < i + ac.ncol; ++j)
             {
                 if (ac.counts[j])
                     {
@@ -54,7 +54,7 @@ namespace
             {
                 return rv;
             }
-        if (refstates.size() != ac.counts.size() / ac.row_size)
+        if (refstates.size() != ac.counts.size() / ac.ncol)
             {
                 throw std::invalid_argument(
                     "incorrect number of reference states");
@@ -67,13 +67,13 @@ namespace
             }
         std::size_t rstate = 0;
         for (std::size_t i = 0; i < ac.counts.size();
-             i += ac.row_size, ++rstate)
+             i += ac.ncol, ++rstate)
             {
                 if (refstates[rstate] >= 0)
                     {
                         auto refindex
                             = static_cast<std::size_t>(refstates[rstate]);
-                        if (refindex >= ac.row_size)
+                        if (refindex >= ac.ncol)
                             {
                                 throw std::invalid_argument(
                                     "reference state greater than max allelic "
@@ -91,12 +91,12 @@ namespace
     {
         double rv = 0.0;
         auto refindex = static_cast<std::size_t>(refstate);
-        if (refindex >= ac.row_size)
+        if (refindex >= ac.ncol)
             {
                 throw std::invalid_argument(
                     "reference state greater than max allelic state");
             }
-        for (std::size_t i = 0; i < ac.counts.size(); i += ac.row_size)
+        for (std::size_t i = 0; i < ac.counts.size(); i += ac.ncol)
             {
                 rv += process_row(ac, i, refindex, power);
             }

--- a/src/summstats/thetah_thetal.cc
+++ b/src/summstats/thetah_thetal.cc
@@ -20,9 +20,9 @@ namespace
             = std::count_if(c.counts.begin(), c.counts.end(),
                             [](const std::int32_t x) { return x > 0; });
         bool ref_seen = false;
-        for(std::size_t i=0;i<c.counts.size();++i)
+        for (std::size_t i = 0; i < c.counts.size(); ++i)
             {
-                if(c.counts[i]>0)
+                if (c.counts[i] > 0)
                     {
                         if (static_cast<std::int8_t>(i) != refstate)
                             {
@@ -89,6 +89,98 @@ namespace
             }
         return stat;
     }
+
+    inline double
+    process_row(const Sequence::AlleleCountMatrix& ac, const std::size_t i,
+                const std::size_t refindex, const double power)
+    {
+        std::int32_t nsam = 0;
+        std::int32_t nnonref = 0;
+        double temp = 0.0;
+        bool ref_seen = false;
+        for (std::size_t j = i; j < i + ac.row_size; ++j)
+            {
+                if (ac.counts[j])
+                    {
+                        nsam += ac.counts[j];
+                        if (j - i != refindex)
+                            {
+                                ++nnonref;
+                                temp += std::pow(ac.counts[j], power);
+                            }
+                        else
+                            {
+                                ref_seen = true;
+                            }
+                    }
+            }
+        if (nnonref > 1)
+            {
+                throw std::runtime_error(
+                    "site has more than one derived state");
+            }
+        if (ref_seen)
+            {
+                double nnm1 = static_cast<double>(nsam * (nsam - 1));
+                return temp / nnm1;
+            }
+        return 0.0;
+    }
+
+    inline double
+    calc_stat(const Sequence::AlleleCountMatrix& ac,
+              const std::vector<std::int8_t>& refstates, const double power)
+    {
+        double rv = 0.0;
+        if (ac.counts.empty())
+            {
+                return rv;
+            }
+        if (refstates.size() != ac.counts.size() / ac.row_size)
+            {
+                throw std::invalid_argument(
+                    "incorrect number of reference states");
+            }
+        if (std::all_of(refstates.begin(), refstates.end(),
+                        [](const std::int8_t i) { return i < 0; }))
+            {
+                throw std::invalid_argument(
+                    "all reference states encoded as missing");
+            }
+        for (std::size_t i = 0; i < ac.counts.size(); i += ac.row_size)
+            {
+                if (refstates[i] >= 0)
+                    {
+                        auto refindex = static_cast<std::size_t>(refstates[i]);
+                        if (refindex >= ac.row_size)
+                            {
+                                throw std::invalid_argument(
+                                    "reference state greater than max allelic "
+                                    "state");
+                            }
+                        rv += process_row(ac, i, refindex, power);
+                    }
+            }
+        return rv;
+    }
+
+    inline double
+    calc_stat(const Sequence::AlleleCountMatrix& ac,
+              const std::int8_t refstate, const double power)
+    {
+        double rv = 0.0;
+        auto refindex = static_cast<std::size_t>(refstate);
+        if (refindex >= ac.row_size)
+            {
+                throw std::invalid_argument(
+                    "reference state greater than max allelic state");
+            }
+        for (std::size_t i = 0; i < ac.counts.size(); i += ac.row_size)
+            {
+                rv += process_row(ac, i, refindex, power);
+            }
+        return rv;
+    }
 } // namespace
 
 namespace Sequence
@@ -116,4 +208,31 @@ namespace Sequence
     {
         return calc_stat(m, refstates, 1.0);
     }
+
+    double
+    thetah(const AlleleCountMatrix& ac, const std::int8_t refstate)
+    {
+        return calc_stat(ac, refstate, 2.0);
+    }
+
+    double
+    thetah(const AlleleCountMatrix& ac,
+           const std::vector<std::int8_t>& refstates)
+    {
+        return calc_stat(ac, refstates, 2.0);
+    }
+
+    double
+    thetal(const AlleleCountMatrix& ac, const std::int8_t refstate)
+    {
+        return calc_stat(ac, refstate, 1.0);
+    }
+
+    double
+    thetal(const AlleleCountMatrix& ac,
+           const std::vector<std::int8_t>& refstates)
+    {
+        return calc_stat(ac, refstates, 1.0);
+    }
+
 } // namespace Sequence

--- a/src/summstats/thetah_thetal.cc
+++ b/src/summstats/thetah_thetal.cc
@@ -4,7 +4,7 @@
 #include <cmath>
 #include <algorithm>
 #include <stdexcept>
-#include <Sequence/VariantMatrix.hpp>
+#include <Sequence/AlleleCountMatrix.hpp>
 
 namespace
 {

--- a/src/summstats/thetah_thetal.cc
+++ b/src/summstats/thetah_thetal.cc
@@ -4,92 +4,10 @@
 #include <cmath>
 #include <algorithm>
 #include <stdexcept>
-#include <Sequence/StateCounts.hpp>
 #include <Sequence/VariantMatrix.hpp>
 
 namespace
 {
-    inline double
-    update(const Sequence::StateCounts& c, const std::int8_t refstate,
-           const double power)
-    {
-        double H = 0.0;
-        double nnm1 = static_cast<double>(c.n * (c.n - 1));
-        //std::size_t has_missing = (c.counts.find(-1) != c.counts.end());
-        std::size_t num_non_missing_states
-            = std::count_if(c.counts.begin(), c.counts.end(),
-                            [](const std::int32_t x) { return x > 0; });
-        bool ref_seen = false;
-        for (std::size_t i = 0; i < c.counts.size(); ++i)
-            {
-                if (c.counts[i] > 0)
-                    {
-                        if (static_cast<std::int8_t>(i) != refstate)
-                            {
-                                H += std::pow(c.counts[i], power);
-                            }
-                        else
-                            {
-                                ref_seen = true;
-                            }
-                    }
-            }
-        if (num_non_missing_states > 2)
-            {
-                throw std::runtime_error(
-                    "the site has more than one derived state");
-            }
-        if (!ref_seen) //The reference state must still be segregating
-                       // TODO: need unit test for this case
-            {
-                return 0.0;
-            }
-        H /= nnm1;
-        return H;
-    }
-
-    inline double
-    calc_stat(const Sequence::VariantMatrix& m, const std::int8_t refstate,
-              const double power)
-    {
-        if (refstate < 0)
-            {
-                throw std::invalid_argument(
-                    "all reference states are encoded as missing");
-            }
-        double stat = 0.0;
-        Sequence::StateCounts counts(refstate);
-        for (std::size_t i = 0; i < m.nsites; ++i)
-            {
-                auto r = get_ConstRowView(m, i);
-                counts(r);
-                stat += update(counts, refstate, power);
-            }
-        return stat;
-    }
-
-    inline double
-    calc_stat(const Sequence::VariantMatrix& m,
-              const std::vector<std::int8_t>& refstates, const double power)
-    {
-        if (std::all_of(refstates.begin(), refstates.end(),
-                        [](const std::int8_t x) { return x < 0; }))
-            {
-                throw std::invalid_argument(
-                    "all reference states are encoded as missing");
-            }
-        double stat = 0.0;
-        Sequence::StateCounts counts;
-        for (std::size_t i = 0; i < m.nsites; ++i)
-            {
-                counts.refstate = refstates[i];
-                auto r = get_ConstRowView(m, i);
-                counts(r);
-                stat += update(counts, refstates[i], power);
-            }
-        return stat;
-    }
-
     inline double
     process_row(const Sequence::AlleleCountMatrix& ac, const std::size_t i,
                 const std::size_t refindex, const double power)
@@ -188,30 +106,6 @@ namespace
 
 namespace Sequence
 {
-    double
-    thetah(const VariantMatrix& m, const std::int8_t refstate)
-    {
-        return calc_stat(m, refstate, 2.0);
-    }
-
-    double
-    thetah(const VariantMatrix& m, const std::vector<std::int8_t>& refstates)
-    {
-        return calc_stat(m, refstates, 2.0);
-    }
-
-    double
-    thetal(const VariantMatrix& m, const std::int8_t refstate)
-    {
-        return calc_stat(m, refstate, 1.0);
-    }
-
-    double
-    thetal(const VariantMatrix& m, const std::vector<std::int8_t>& refstates)
-    {
-        return calc_stat(m, refstates, 1.0);
-    }
-
     double
     thetah(const AlleleCountMatrix& ac, const std::int8_t refstate)
     {

--- a/src/summstats/thetah_thetal.cc
+++ b/src/summstats/thetah_thetal.cc
@@ -147,11 +147,14 @@ namespace
                 throw std::invalid_argument(
                     "all reference states encoded as missing");
             }
-        for (std::size_t i = 0; i < ac.counts.size(); i += ac.row_size)
+        std::size_t rstate = 0;
+        for (std::size_t i = 0; i < ac.counts.size();
+             i += ac.row_size, ++rstate)
             {
-                if (refstates[i] >= 0)
+                if (refstates[rstate] >= 0)
                     {
-                        auto refindex = static_cast<std::size_t>(refstates[i]);
+                        auto refindex
+                            = static_cast<std::size_t>(refstates[rstate]);
                         if (refindex >= ac.row_size)
                             {
                                 throw std::invalid_argument(

--- a/src/summstats/thetah_thetal.cc
+++ b/src/summstats/thetah_thetal.cc
@@ -90,6 +90,10 @@ namespace
               const std::int8_t refstate, const double power)
     {
         double rv = 0.0;
+        if (ac.counts.empty())
+            {
+                return rv;
+            }
         auto refindex = static_cast<std::size_t>(refstate);
         if (refindex >= ac.ncol)
             {

--- a/src/summstats/thetapi.cc
+++ b/src/summstats/thetapi.cc
@@ -1,6 +1,5 @@
 #include <stdexcept>
-#include <Sequence/VariantMatrix.hpp>
-#include <Sequence/VariantMatrixViews.hpp>
+#include <Sequence/AlleleCountMatrix.hpp>
 
 namespace Sequence
 {

--- a/src/summstats/thetapi.cc
+++ b/src/summstats/thetapi.cc
@@ -1,33 +1,9 @@
 #include <stdexcept>
-#include <Sequence/StateCounts.hpp>
 #include <Sequence/VariantMatrix.hpp>
 #include <Sequence/VariantMatrixViews.hpp>
 
 namespace Sequence
 {
-    double
-    thetapi(const VariantMatrix& m)
-    {
-        double pi = 0.0;
-        StateCounts counts;
-        for (std::size_t site = 0; site < m.nsites; ++site)
-            {
-                auto site_view = get_ConstRowView(m, site);
-                counts(site_view);
-                double sshom = 0.0; //sum of site homozygosity
-                for (std::size_t i = 0; i < counts.max_allele_idx + 1; ++i)
-                    {
-                        auto x = counts.counts[i];
-                        sshom += static_cast<double>(x)
-                                 * static_cast<double>(x - 1.0);
-                    }
-                double nnm1 = (static_cast<double>(counts.n)
-                               * (static_cast<double>(counts.n) - 1.0));
-                pi += 1.0 - sshom / nnm1;
-            }
-        return pi;
-    }
-
     double
     thetapi(const AlleleCountMatrix& ac)
     {

--- a/src/summstats/thetapi.cc
+++ b/src/summstats/thetapi.cc
@@ -7,11 +7,11 @@ namespace Sequence
     thetapi(const AlleleCountMatrix& ac)
     {
         double pi = 0.0;
-        for (std::size_t i = 0; i < ac.counts.size(); i += ac.row_size)
+        for (std::size_t i = 0; i < ac.counts.size(); i += ac.ncol)
             {
                 std::int32_t nsam = 0;
                 double homozygosity = 0.0;
-                for (std::size_t j = i; j < i + ac.row_size; ++j)
+                for (std::size_t j = i; j < i + ac.ncol; ++j)
                     {
                         nsam += ac.counts[j];
                         homozygosity += static_cast<double>(

--- a/src/summstats/thetapi.cc
+++ b/src/summstats/thetapi.cc
@@ -42,7 +42,6 @@ namespace Sequence
                         homozygosity += static_cast<double>(
                             ac.counts[j] * (ac.counts[j] - 1));
                     }
-
                 pi += 1.0
                       - homozygosity / static_cast<double>(nsam * (nsam - 1));
             }

--- a/src/summstats/thetapi.cc
+++ b/src/summstats/thetapi.cc
@@ -15,14 +15,36 @@ namespace Sequence
                 auto site_view = get_ConstRowView(m, site);
                 counts(site_view);
                 double sshom = 0.0; //sum of site homozygosity
-                for (auto& x : counts.counts)
+                for (std::size_t i = 0; i < counts.max_allele_idx + 1; ++i)
                     {
+                        auto x = counts.counts[i];
                         sshom += static_cast<double>(x)
                                  * static_cast<double>(x - 1.0);
                     }
                 double nnm1 = (static_cast<double>(counts.n)
                                * (static_cast<double>(counts.n) - 1.0));
                 pi += 1.0 - sshom / nnm1;
+            }
+        return pi;
+    }
+
+    double
+    thetapi(const AlleleCountMatrix& ac)
+    {
+        double pi = 0.0;
+        for (std::size_t i = 0; i < ac.counts.size(); i += ac.row_size)
+            {
+                std::int32_t nsam = 0;
+                double homozygosity = 0.0;
+                for (std::size_t j = i; j < i + ac.row_size; ++j)
+                    {
+                        nsam += ac.counts[j];
+                        homozygosity += static_cast<double>(
+                            ac.counts[j] * (ac.counts[j] - 1));
+                    }
+
+                pi += 1.0
+                      - homozygosity / static_cast<double>(nsam * (nsam - 1));
             }
         return pi;
     }

--- a/src/summstats/thetaw.cc
+++ b/src/summstats/thetaw.cc
@@ -28,4 +28,28 @@ namespace Sequence
         return w;
     }
 
+    double
+    thetaw(const AlleleCountMatrix& ac)
+    {
+        double w = 0.0;
+        for (std::size_t i = 0; i < ac.counts.size(); i += ac.row_size)
+            {
+                std::int32_t nsam = 0, nstates = 0;
+                for (std::size_t j = i; j < i + ac.row_size; ++j)
+                    {
+                        if (ac.counts[j] > 0)
+                            {
+                                nsam += ac.counts[j];
+                                nstates++;
+                            }
+                    }
+                if (nstates > 1)
+                    {
+                        auto denom = summstats_aux::a_sub_n(nsam);
+                        w += static_cast<double>(nstates - 1) / denom;
+                    }
+            }
+        return w;
+    }
+
 } // namespace Sequence

--- a/src/summstats/thetaw.cc
+++ b/src/summstats/thetaw.cc
@@ -9,10 +9,10 @@ namespace Sequence
     thetaw(const AlleleCountMatrix& ac)
     {
         double w = 0.0;
-        for (std::size_t i = 0; i < ac.counts.size(); i += ac.row_size)
+        for (std::size_t i = 0; i < ac.counts.size(); i += ac.ncol)
             {
                 std::int32_t nsam = 0, nstates = 0;
-                for (std::size_t j = i; j < i + ac.row_size; ++j)
+                for (std::size_t j = i; j < i + ac.ncol; ++j)
                     {
                         if (ac.counts[j] > 0)
                             {

--- a/src/summstats/thetaw.cc
+++ b/src/summstats/thetaw.cc
@@ -11,12 +11,13 @@ namespace Sequence
         double w = 0.0;
         for (std::size_t i = 0; i < ac.counts.size(); i += ac.ncol)
             {
-                std::int32_t nsam = 0, nstates = 0;
+                std::uint32_t nsam = 0, nstates = 0;
                 for (std::size_t j = i; j < i + ac.ncol; ++j)
                     {
                         if (ac.counts[j] > 0)
                             {
-                                nsam += ac.counts[j];
+                                nsam += static_cast<std::uint32_t>(
+                                    ac.counts[j]);
                                 nstates++;
                             }
                     }

--- a/src/summstats/thetaw.cc
+++ b/src/summstats/thetaw.cc
@@ -1,7 +1,6 @@
 #include <algorithm>
 #include <stdexcept>
-#include <Sequence/VariantMatrix.hpp>
-#include <Sequence/VariantMatrixViews.hpp>
+#include <Sequence/AlleleCountMatrix.hpp>
 #include <Sequence/summstats/auxillary.hpp>
 
 namespace Sequence

--- a/src/summstats/thetaw.cc
+++ b/src/summstats/thetaw.cc
@@ -1,33 +1,11 @@
 #include <algorithm>
 #include <stdexcept>
-#include <Sequence/StateCounts.hpp>
 #include <Sequence/VariantMatrix.hpp>
 #include <Sequence/VariantMatrixViews.hpp>
 #include <Sequence/summstats/auxillary.hpp>
 
 namespace Sequence
 {
-    double
-    thetaw(const VariantMatrix& m)
-    {
-        double w = 0.0;
-        StateCounts counts;
-        for (std::size_t site = 0; site < m.nsites; ++site)
-            {
-                auto site_view = get_RowView(m, site);
-                counts(site_view);
-                if (counts.counts.size() > 1)
-                    {
-                        auto nstates = counts.counts.size()
-                                       - std::count(counts.counts.begin(),
-                                                    counts.counts.end(), 0);
-                        auto denom = summstats_aux::a_sub_n(counts.n);
-                        w += static_cast<double>(nstates - 1) / denom;
-                    }
-            }
-        return w;
-    }
-
     double
     thetaw(const AlleleCountMatrix& ac)
     {

--- a/src/variant_matrix/AlleleCountMatrix.cc
+++ b/src/variant_matrix/AlleleCountMatrix.cc
@@ -1,0 +1,34 @@
+#include <Sequence/AlleleCountMatrix.hpp>
+#include <Sequence/StateCounts.hpp>
+
+namespace Sequence
+{
+    std::vector<std::int32_t>
+    AlleleCountMatrix::init_counts(const VariantMatrix& m)
+    {
+        if (m.max_allele < 0)
+            {
+                throw std::invalid_argument("matrix max_allele must be >= 0");
+            }
+        std::vector<std::int32_t> counts;
+        counts.reserve(m.nsam * static_cast<std::size_t>(m.max_allele + 1));
+        StateCounts c;
+        for (std::size_t i = 0; i < m.nsites; ++i)
+            {
+                auto r = get_ConstRowView(m, i);
+                c(r);
+                for (std::size_t j = 0;
+                     j < static_cast<std::size_t>(m.max_allele + 1); ++j)
+                    {
+                        counts.push_back(c.counts[j]);
+                    }
+            }
+        return counts;
+    }
+
+    AlleleCountMatrix::AlleleCountMatrix(const VariantMatrix& m)
+        : counts(init_counts(m)),
+          row_size(static_cast<std::size_t>(m.max_allele) + 1), nsam(m.nsam)
+    {
+    }
+}

--- a/src/variant_matrix/AlleleCountMatrix.cc
+++ b/src/variant_matrix/AlleleCountMatrix.cc
@@ -36,7 +36,7 @@ namespace Sequence
         : counts(init_counts(m)),
           ncol(!m.data.empty() ? static_cast<std::size_t>(m.max_allele) + 1
                                : 0),
-          nrow(!m.data.empty() ? m.data.size() / ncol : 0), nsam(m.nsam)
+          nrow(!m.data.empty() ? counts.size() / ncol : 0), nsam(m.nsam)
     {
     }
 

--- a/src/variant_matrix/AlleleCountMatrix.cc
+++ b/src/variant_matrix/AlleleCountMatrix.cc
@@ -34,7 +34,9 @@ namespace Sequence
 
     AlleleCountMatrix::AlleleCountMatrix(const VariantMatrix& m)
         : counts(init_counts(m)),
-          row_size(static_cast<std::size_t>(m.max_allele) + 1), nsam(m.nsam)
+          ncol(!m.data.empty() ? static_cast<std::size_t>(m.max_allele) + 1
+                               : 0),
+          nrow(!m.data.empty() ? m.data.size() / ncol : 0), nsam(m.nsam)
     {
     }
 } // namespace Sequence

--- a/src/variant_matrix/AlleleCountMatrix.cc
+++ b/src/variant_matrix/AlleleCountMatrix.cc
@@ -39,4 +39,16 @@ namespace Sequence
           nrow(!m.data.empty() ? m.data.size() / ncol : 0), nsam(m.nsam)
     {
     }
+
+    std::pair<std::vector<std::int32_t>::const_iterator,
+              std::vector<std::int32_t>::const_iterator>
+    AlleleCountMatrix::row(const std::size_t i) const
+    {
+        if (i >= nrow)
+            {
+                throw std::out_of_range("row index out of range");
+            }
+        return std::make_pair(counts.begin() + i * ncol,
+                              counts.begin() + i * ncol + ncol);
+    }
 } // namespace Sequence

--- a/src/variant_matrix/AlleleCountMatrix.cc
+++ b/src/variant_matrix/AlleleCountMatrix.cc
@@ -1,3 +1,4 @@
+#include <stdexcept>
 #include <Sequence/AlleleCountMatrix.hpp>
 #include <Sequence/StateCounts.hpp>
 
@@ -16,6 +17,11 @@ namespace Sequence
         for (std::size_t i = 0; i < m.nsites; ++i)
             {
                 auto r = get_ConstRowView(m, i);
+                if (static_cast<std::int8_t>(c.max_allele_idx) > m.max_allele)
+                    {
+                        throw std::runtime_error("found allele value greater "
+                                                 "than matrix.max_allele");
+                    }
                 c(r);
                 for (std::size_t j = 0;
                      j < static_cast<std::size_t>(m.max_allele + 1); ++j)
@@ -31,4 +37,4 @@ namespace Sequence
           row_size(static_cast<std::size_t>(m.max_allele) + 1), nsam(m.nsam)
     {
     }
-}
+} // namespace Sequence

--- a/src/variant_matrix/StateCounts.cc
+++ b/src/variant_matrix/StateCounts.cc
@@ -5,30 +5,34 @@
 namespace Sequence
 {
     StateCounts::StateCounts()
-        : counts(std::vector<std::int32_t>(max_allele + 1, 0)), n{ 0u },
-          refstate(-1)
+        : counts(std::vector<std::int32_t>(max_allele + 1, 0)),
+          max_allele_idx{ 0 }, n{ 0u }, refstate(-1)
     {
     }
 
     StateCounts::StateCounts(const std::int8_t refstate_)
-        : counts(std::vector<std::int32_t>(max_allele + 1, 0)), n{ 0u },
-          refstate(refstate_)
+        : counts(std::vector<std::int32_t>(max_allele + 1, 0)),
+          max_allele_idx{ 0 }, n{ 0u }, refstate(refstate_)
     {
     }
 
     void
     StateCounts::operator()(ConstRowView& row)
     {
-        std::fill(counts.begin(), counts.end(), 0);
+        std::fill(counts.begin(), counts.begin() + max_allele_idx + 1, 0);
         n = 0;
-        for (auto& i : row)
+        max_allele_idx = 0;
+        for (std::size_t i = 0; i < row.size(); ++i)
             {
-                if (i >= 0)
+                auto ri = row[i];
+                if (ri >= 0)
                     {
                         ++n;
-                        ++counts[static_cast<std::size_t>(i)];
+                        ++counts[static_cast<std::size_t>(ri)];
+                        max_allele_idx = std::max(
+                            max_allele_idx, static_cast<std::size_t>(ri));
                     }
-                else if (i == VariantMatrix::mask)
+                else if (ri == VariantMatrix::mask)
                     {
                         throw std::invalid_argument(
                             "reserved value encountered");
@@ -39,16 +43,20 @@ namespace Sequence
     void
     StateCounts::operator()(const RowView& row)
     {
-        std::fill(counts.begin(), counts.end(), 0);
+        std::fill(counts.begin(), counts.begin() + max_allele_idx + 1, 0);
         n = 0;
-        for (auto& i : row)
+        max_allele_idx = 0;
+        for (std::size_t i = 0; i < row.size(); ++i)
             {
-                if (i >= 0)
+                auto ri = row[i];
+                if (ri >= 0)
                     {
                         ++n;
-                        ++counts[static_cast<std::size_t>(i)];
+                        ++counts[static_cast<std::size_t>(ri)];
+                        max_allele_idx = std::max(
+                            max_allele_idx, static_cast<std::size_t>(ri));
                     }
-                else if (i == VariantMatrix::mask)
+                else if (ri == VariantMatrix::mask)
                     {
                         throw std::invalid_argument(
                             "reserved value encountered");

--- a/src/variant_matrix/VariantMatrix.cc
+++ b/src/variant_matrix/VariantMatrix.cc
@@ -1,8 +1,36 @@
 #include <Sequence/VariantMatrix.hpp>
+#include <Sequence/VariantMatrixViews.hpp>
+#include <Sequence/StateCounts.hpp>
 #include <stdexcept>
 
 namespace Sequence
 {
+    std::vector<std::int32_t>
+    AlleleCountMatrix::init_counts(const VariantMatrix& m)
+    {
+        std::vector<std::int32_t> counts;
+        counts.reserve(m.nsam * static_cast<std::size_t>(m.max_allele + 1));
+        StateCounts c;
+        for (std::size_t i = 0; i < m.nsites; ++i)
+            {
+                auto r = get_ConstRowView(m, i);
+                c(r);
+                for (std::size_t j = 0;
+                     j < static_cast<std::size_t>(m.max_allele + 1); ++j)
+                    {
+                        counts.push_back(c.counts[j]);
+                    }
+            }
+        return counts;
+    }
+
+    AlleleCountMatrix::AlleleCountMatrix(const VariantMatrix& m)
+        : counts(init_counts(m)), row_size{
+              static_cast<std::size_t>(m.max_allele) + 1
+          }
+    {
+    }
+
     const std::int8_t VariantMatrix::mask
         = std::numeric_limits<std::int8_t>::min();
     // Non range-checked access
@@ -42,4 +70,11 @@ namespace Sequence
             }
         return data.at(site * nsam + haplotype);
     }
-}
+
+    //AlleleCountMatrix
+    //VariantMatrix::count_alleles() const
+    //{
+    //    return AlleleCountMatrix(std::move(counts),
+    //                             static_cast<std::size_t>(max_allele + 1));
+    //}
+} // namespace Sequence

--- a/src/variant_matrix/VariantMatrix.cc
+++ b/src/variant_matrix/VariantMatrix.cc
@@ -5,35 +5,6 @@
 
 namespace Sequence
 {
-    std::vector<std::int32_t>
-    AlleleCountMatrix::init_counts(const VariantMatrix& m)
-    {
-        if (m.max_allele < 0)
-            {
-                throw std::invalid_argument("matrix max_allele must be >= 0");
-            }
-        std::vector<std::int32_t> counts;
-        counts.reserve(m.nsam * static_cast<std::size_t>(m.max_allele + 1));
-        StateCounts c;
-        for (std::size_t i = 0; i < m.nsites; ++i)
-            {
-                auto r = get_ConstRowView(m, i);
-                c(r);
-                for (std::size_t j = 0;
-                     j < static_cast<std::size_t>(m.max_allele + 1); ++j)
-                    {
-                        counts.push_back(c.counts[j]);
-                    }
-            }
-        return counts;
-    }
-
-    AlleleCountMatrix::AlleleCountMatrix(const VariantMatrix& m)
-        : counts(init_counts(m)),
-          row_size(static_cast<std::size_t>(m.max_allele) + 1), nsam(m.nsam)
-    {
-    }
-
     const std::int8_t VariantMatrix::mask
         = std::numeric_limits<std::int8_t>::min();
     // Non range-checked access

--- a/src/variant_matrix/VariantMatrix.cc
+++ b/src/variant_matrix/VariantMatrix.cc
@@ -8,6 +8,10 @@ namespace Sequence
     std::vector<std::int32_t>
     AlleleCountMatrix::init_counts(const VariantMatrix& m)
     {
+        if (m.max_allele < 0)
+            {
+                throw std::invalid_argument("matrix max_allele must be >= 0");
+            }
         std::vector<std::int32_t> counts;
         counts.reserve(m.nsam * static_cast<std::size_t>(m.max_allele + 1));
         StateCounts c;

--- a/src/variant_matrix/VariantMatrix.cc
+++ b/src/variant_matrix/VariantMatrix.cc
@@ -29,9 +29,8 @@ namespace Sequence
     }
 
     AlleleCountMatrix::AlleleCountMatrix(const VariantMatrix& m)
-        : counts(init_counts(m)), row_size{
-              static_cast<std::size_t>(m.max_allele) + 1
-          }
+        : counts(init_counts(m)),
+          row_size(static_cast<std::size_t>(m.max_allele) + 1), nsam(m.nsam)
     {
     }
 

--- a/src/variant_matrix/VariantMatrix.cc
+++ b/src/variant_matrix/VariantMatrix.cc
@@ -44,11 +44,4 @@ namespace Sequence
             }
         return data.at(site * nsam + haplotype);
     }
-
-    //AlleleCountMatrix
-    //VariantMatrix::count_alleles() const
-    //{
-    //    return AlleleCountMatrix(std::move(counts),
-    //                             static_cast<std::size_t>(max_allele + 1));
-    //}
 } // namespace Sequence

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -46,6 +46,7 @@ polySiteVectorTest.cc \
 PolyTableSliceTest.cc \
 stateCounterTest.cc \
 VariantMatrixTest.cc \
+testAlleleCountMatrix.cc \
 testClassicSummstats.cc \
 testClassicSummstatsEmptyVariantMatrix.cc \
 testLD.cc \

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -124,7 +124,7 @@ am__libseq_unit_tests_SOURCES_DIST = libseq_unit_tests.cc \
 	SeqConversions.cc RedundancyCom95test.cc alphabets.cc \
 	polySiteVectorTest.cc PolyTableSliceTest.cc \
 	stateCounterTest.cc VariantMatrixTest.cc \
-	testClassicSummstats.cc \
+	testAlleleCountMatrix.cc testClassicSummstats.cc \
 	testClassicSummstatsEmptyVariantMatrix.cc testLD.cc \
 	testGarudStatistics.cc
 @BUNIT_TEST_PRESENT_TRUE@am_libseq_unit_tests_OBJECTS =  \
@@ -152,6 +152,7 @@ am__libseq_unit_tests_SOURCES_DIST = libseq_unit_tests.cc \
 @BUNIT_TEST_PRESENT_TRUE@	PolyTableSliceTest.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	stateCounterTest.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	VariantMatrixTest.$(OBJEXT) \
+@BUNIT_TEST_PRESENT_TRUE@	testAlleleCountMatrix.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	testClassicSummstats.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	testClassicSummstatsEmptyVariantMatrix.$(OBJEXT) \
 @BUNIT_TEST_PRESENT_TRUE@	testLD.$(OBJEXT) \
@@ -579,6 +580,7 @@ top_srcdir = @top_srcdir@
 @BUNIT_TEST_PRESENT_TRUE@PolyTableSliceTest.cc \
 @BUNIT_TEST_PRESENT_TRUE@stateCounterTest.cc \
 @BUNIT_TEST_PRESENT_TRUE@VariantMatrixTest.cc \
+@BUNIT_TEST_PRESENT_TRUE@testAlleleCountMatrix.cc \
 @BUNIT_TEST_PRESENT_TRUE@testClassicSummstats.cc \
 @BUNIT_TEST_PRESENT_TRUE@testClassicSummstatsEmptyVariantMatrix.cc \
 @BUNIT_TEST_PRESENT_TRUE@testLD.cc \
@@ -661,6 +663,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libseq_unit_tests.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/polySiteVectorTest.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/stateCounterTest.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/testAlleleCountMatrix.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/testClassicSummstats.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/testClassicSummstatsEmptyVariantMatrix.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/testGarudStatistics.Po@am__quote@

--- a/test/VariantMatrixFixture.hpp
+++ b/test/VariantMatrixFixture.hpp
@@ -7,10 +7,12 @@ struct dataset
     using data_type = decltype(Sequence::VariantMatrix::data);
     using positions_type = decltype(Sequence::VariantMatrix::positions);
     Sequence::VariantMatrix m;
+    Sequence::AlleleCountMatrix c;
     dataset()
         : m{ data_type{ 1, 1, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0,
                         1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0 },
-             positions_type{ 0.1, 0.2, 0.3 } }
+             positions_type{ 0.1, 0.2, 0.3 } },
+          c{ m }
     {
     }
 };

--- a/test/VariantMatrixFixture.hpp
+++ b/test/VariantMatrixFixture.hpp
@@ -2,6 +2,8 @@
 #define LIBSEQUENCE_TESTS_VARIANTMATRIXFIXTURE_HPP__
 
 #include <Sequence/VariantMatrix.hpp>
+#include <Sequence/AlleleCountMatrix.hpp>
+
 struct dataset
 {
     using data_type = decltype(Sequence::VariantMatrix::data);

--- a/test/VariantMatrixFixture.hpp
+++ b/test/VariantMatrixFixture.hpp
@@ -22,12 +22,13 @@ struct invariantdataset
     using data_type = decltype(Sequence::VariantMatrix::data);
     using positions_type = decltype(Sequence::VariantMatrix::positions);
     Sequence::VariantMatrix empty, invariant;
+    Sequence::AlleleCountMatrix empty_counts, invariant_counts;
     invariantdataset()
-        : empty{ data_type{}, positions_type{} }, invariant{
-              data_type{ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-                         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 },
-              positions_type{ 0.1, 0.2, 0.3 }
-          }
+        : empty{ data_type{}, positions_type{} },
+          invariant{ data_type{ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 },
+                     positions_type{ 0.1, 0.2, 0.3 } },
+          empty_counts(empty), invariant_counts(invariant)
     {
     }
 };

--- a/test/VariantMatrixTest.cc
+++ b/test/VariantMatrixTest.cc
@@ -1,5 +1,6 @@
 //! \file VariantMatrixTest.cc @brief Tests for Sequence/VariantMatrix.hpp
 #include <Sequence/VariantMatrix.hpp>
+#include <Sequence/AlleleCountMatrix.hpp>
 #include <Sequence/VariantMatrixViews.hpp>
 #include <boost/test/unit_test.hpp>
 #include <algorithm>

--- a/test/VariantMatrixTest.cc
+++ b/test/VariantMatrixTest.cc
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(test_max_allele)
     Sequence::VariantMatrix vm(m.data,m.positions);
     BOOST_CHECK_EQUAL(vm.max_allele, 5);
     Sequence::AlleleCountMatrix vmc(vm);
-    BOOST_REQUIRE_EQUAL(vmc.row_size, 6);
+    BOOST_REQUIRE_EQUAL(vmc.ncol, 6);
 }
 
 BOOST_AUTO_TEST_CASE(test_range_exceptions)

--- a/test/VariantMatrixTest.cc
+++ b/test/VariantMatrixTest.cc
@@ -11,10 +11,10 @@ struct vmatrix_fixture
     std::vector<std::int8_t> input_data;
     std::vector<double> input_pos;
     Sequence::VariantMatrix m, m2;
-
+    Sequence::AlleleCountMatrix c, c2;
     vmatrix_fixture()
         : input_data(make_input_data()), input_pos(make_intput_pos()),
-          m(input_data, input_pos), m2(input_data, input_pos)
+          m(input_data, input_pos), m2(input_data, input_pos), c{ m }, c2{ m2 }
     {
         // The two VariantMatrix objects
         // have same data, but different internal
@@ -59,6 +59,16 @@ BOOST_AUTO_TEST_CASE(test_construction)
                               std::vector<double>(5, 0.0));
     BOOST_REQUIRE_EQUAL(m.nsites, 5);
     BOOST_REQUIRE_EQUAL(m.nsam, 20);
+    BOOST_REQUIRE_EQUAL(m.max_allele, 1);
+}
+
+BOOST_AUTO_TEST_CASE(test_max_allele)
+{
+    m.data[3] = 5;
+    Sequence::VariantMatrix vm(m.data,m.positions);
+    BOOST_CHECK_EQUAL(vm.max_allele, 5);
+    Sequence::AlleleCountMatrix vmc(vm);
+    BOOST_REQUIRE_EQUAL(vmc.row_size, 6);
 }
 
 BOOST_AUTO_TEST_CASE(test_range_exceptions)

--- a/test/testAlleleCountMatrix.cc
+++ b/test/testAlleleCountMatrix.cc
@@ -1,0 +1,19 @@
+//! \file testAlleleCountMatrix.cc @brief Tests for Sequence/VariantMatrix.hpp
+#include "VariantMatrixFixture.hpp"
+#include <boost/test/unit_test.hpp>
+#include <algorithm>
+#include <numeric> //for std::iota
+#include <iterator>
+
+BOOST_FIXTURE_TEST_SUITE(test_allele_count_matrix, dataset)
+
+BOOST_AUTO_TEST_CASE(test_max_allele_exception)
+{
+	//Change some data in m so that m[i] > m.max_allele
+	m.data[0] = 5;
+
+	BOOST_REQUIRE_THROW(Sequence::AlleleCountMatrix ac(m),std::runtime_error);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/test/testClassicSummstats.cc
+++ b/test/testClassicSummstats.cc
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(test_thetapi_with_mising_data)
         {
             m.data[i] = -i;
         }
-    auto pi = Sequence::thetapi(c);
+    auto pi = Sequence::thetapi(Sequence::AlleleCountMatrix(m));
 
     auto manual = manual_pi(m);
     // Cannot require equal b/c we aren't doing ops

--- a/test/testClassicSummstats.cc
+++ b/test/testClassicSummstats.cc
@@ -65,13 +65,11 @@ BOOST_FIXTURE_TEST_SUITE(test_classic_stats, dataset)
 
 BOOST_AUTO_TEST_CASE(test_thetapi)
 {
-    auto pi = Sequence::thetapi(m);
+    auto pi = Sequence::thetapi(c);
     auto manual = manual_pi(m);
     // Cannot require equal b/c we aren't doing ops
     // in same order.
     BOOST_CHECK_CLOSE(pi, manual, 1e-6);
-    auto pi_from_counts = Sequence::thetapi(c);
-    BOOST_CHECK_CLOSE(pi, pi_from_counts, 1e-6);
 }
 
 BOOST_AUTO_TEST_CASE(test_thetapi_with_mising_data)
@@ -85,7 +83,7 @@ BOOST_AUTO_TEST_CASE(test_thetapi_with_mising_data)
         {
             m.data[i] = -i;
         }
-    auto pi = Sequence::thetapi(m);
+    auto pi = Sequence::thetapi(c);
 
     auto manual = manual_pi(m);
     // Cannot require equal b/c we aren't doing ops
@@ -153,7 +151,7 @@ BOOST_AUTO_TEST_CASE(test_thetaw)
 // all we're doing below is
 // checking the denominator.
 {
-    auto w = Sequence::thetaw(m);
+    auto w = Sequence::thetaw(c);
     double S = m.nsites;
     double d = 0.0;
     for (int i = 1; i < m.nsam; ++i)
@@ -162,23 +160,17 @@ BOOST_AUTO_TEST_CASE(test_thetaw)
         }
     auto manual = S / d;
     BOOST_CHECK_CLOSE(w, manual, 1e-6);
-    auto w2 = Sequence::thetaw(c);
-    BOOST_CHECK_CLOSE(w, w2, 1e-6);
 }
 
 BOOST_AUTO_TEST_CASE(test_thetah)
 // Simplest case
 {
-    auto h0 = Sequence::thetah(m, 0);
-    auto h1 = Sequence::thetah(m, 1);
-    auto h0c = Sequence::thetah(c, 0);
-    auto h1c = Sequence::thetah(c, 1);
+    auto h0 = Sequence::thetah(c, 0);
+    auto h1 = Sequence::thetah(c, 1);
     auto m0 = manual_thetah(m, 0);
     auto m1 = manual_thetah(m, 1);
     BOOST_CHECK_CLOSE(h0, m0, 1e-6);
     BOOST_CHECK_CLOSE(h1, m1, 1e-6);
-    BOOST_CHECK_CLOSE(h0, h0c, 1e-6);
-    BOOST_CHECK_CLOSE(h1, h1c, 1e-6);
 }
 
 BOOST_AUTO_TEST_CASE(test_faywuh)
@@ -188,23 +180,11 @@ BOOST_AUTO_TEST_CASE(test_faywuh)
 // we can compare results from the various functions
 // in order to test.
 {
-    auto h = Sequence::thetah(m, 0);
-    auto pi = Sequence::thetapi(m);
-    auto fwh = Sequence::faywuh(m, 0);
-    auto fwhac = Sequence::faywuh(c, 0);
-    BOOST_CHECK_CLOSE(fwh, fwhac, 1e-6);
+    auto h = Sequence::thetah(c, 0);
+    auto pi = Sequence::thetapi(c);
+    auto fwh = Sequence::faywuh(c, 0);
     BOOST_CHECK_EQUAL(fwh + h, pi);
     BOOST_REQUIRE_EQUAL(pi - h, fwh);
-}
-
-BOOST_AUTO_TEST_CASE(theta_hprime)
-{
-    auto hp = Sequence::hprime(m, 0);
-    auto hpac = Sequence::hprime(c, 0);
-    BOOST_CHECK_CLOSE(hp, hpac, 1e-6);
-    hp = Sequence::hprime(m, 1);
-    hpac = Sequence::hprime(c, 1);
-    BOOST_CHECK_CLOSE(hp, hpac, 1e-6);
 }
 
 BOOST_AUTO_TEST_CASE(test_thetah_multiple_derived_states)
@@ -219,12 +199,12 @@ BOOST_AUTO_TEST_CASE(test_thetah_multiple_derived_states)
                     f[i] = 4;
                 }
         }
-    BOOST_REQUIRE_THROW(auto h = Sequence::thetah(m, 0), std::runtime_error);
+    BOOST_REQUIRE_THROW(auto h = Sequence::thetah(c, 0), std::runtime_error);
     for (std::size_t i = 0; i < f.size(); ++i)
         {
             f[i] = 3;
         }
-    BOOST_REQUIRE_NO_THROW(auto h = Sequence::thetah(m, 0));
+    BOOST_REQUIRE_NO_THROW(auto h = Sequence::thetah(c, 0));
 }
 
 BOOST_AUTO_TEST_CASE(test_num_haplotypes)

--- a/test/testClassicSummstats.cc
+++ b/test/testClassicSummstats.cc
@@ -195,6 +195,13 @@ BOOST_AUTO_TEST_CASE(test_faywuh)
     BOOST_REQUIRE_EQUAL(pi - h, fwh);
 }
 
+BOOST_AUTO_TEST_CASE(theta_hprime)
+{
+    auto hp = Sequence::hprime(m, 0);
+    auto hpac = Sequence::hprime(c, 0);
+    BOOST_CHECK_CLOSE(hp, hpac, 1e-6);
+}
+
 BOOST_AUTO_TEST_CASE(test_thetah_multiple_derived_states)
 {
     // Create a site with > 2 derived states

--- a/test/testClassicSummstats.cc
+++ b/test/testClassicSummstats.cc
@@ -70,7 +70,6 @@ BOOST_AUTO_TEST_CASE(test_thetapi)
     // Cannot require equal b/c we aren't doing ops
     // in same order.
     BOOST_CHECK_CLOSE(pi, manual, 1e-6);
-    Sequence::AlleleCountMatrix c(m);
     auto pi_from_counts = Sequence::thetapi(c);
     BOOST_CHECK_CLOSE(pi, pi_from_counts, 1e-6);
 }

--- a/test/testClassicSummstats.cc
+++ b/test/testClassicSummstats.cc
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(test_nbiallelic_sites)
 BOOST_AUTO_TEST_CASE(test_count_alleles)
 {
     auto S2 = Sequence::nbiallelic_sites(c);
-    auto ac = Sequence::allele_counts(m);
+    auto ac = Sequence::allele_counts(c);
     auto nb = 0;
     for (auto i : ac)
         {

--- a/test/testClassicSummstats.cc
+++ b/test/testClassicSummstats.cc
@@ -191,6 +191,8 @@ BOOST_AUTO_TEST_CASE(test_faywuh)
     auto h = Sequence::thetah(m, 0);
     auto pi = Sequence::thetapi(m);
     auto fwh = Sequence::faywuh(m, 0);
+    auto fwhac = Sequence::faywuh(c, 0);
+    BOOST_CHECK_CLOSE(fwh, fwhac, 1e-6);
     BOOST_CHECK_EQUAL(fwh + h, pi);
     BOOST_REQUIRE_EQUAL(pi - h, fwh);
 }
@@ -199,6 +201,9 @@ BOOST_AUTO_TEST_CASE(theta_hprime)
 {
     auto hp = Sequence::hprime(m, 0);
     auto hpac = Sequence::hprime(c, 0);
+    BOOST_CHECK_CLOSE(hp, hpac, 1e-6);
+    hp = Sequence::hprime(m, 1);
+    hpac = Sequence::hprime(c, 1);
     BOOST_CHECK_CLOSE(hp, hpac, 1e-6);
 }
 

--- a/test/testClassicSummstats.cc
+++ b/test/testClassicSummstats.cc
@@ -199,12 +199,16 @@ BOOST_AUTO_TEST_CASE(test_thetah_multiple_derived_states)
                     f[i] = 4;
                 }
         }
-    BOOST_REQUIRE_THROW(auto h = Sequence::thetah(c, 0), std::runtime_error);
+    //We have to make data copies here so that 
+    //max_allele is reset.
+    Sequence::VariantMatrix m2(m.data, m.positions);
+    BOOST_REQUIRE_THROW(auto h = Sequence::thetah(Sequence::AlleleCountMatrix(m2), 0), std::runtime_error);
     for (std::size_t i = 0; i < f.size(); ++i)
         {
             f[i] = 3;
         }
-    BOOST_REQUIRE_NO_THROW(auto h = Sequence::thetah(c, 0));
+    Sequence::VariantMatrix m3(m.data, m.positions);
+    BOOST_REQUIRE_NO_THROW(auto h = Sequence::thetah(Sequence::AlleleCountMatrix(m3), 0));
 }
 
 BOOST_AUTO_TEST_CASE(test_num_haplotypes)

--- a/test/testClassicSummstats.cc
+++ b/test/testClassicSummstats.cc
@@ -171,10 +171,14 @@ BOOST_AUTO_TEST_CASE(test_thetah)
 {
     auto h0 = Sequence::thetah(m, 0);
     auto h1 = Sequence::thetah(m, 1);
+    auto h0c = Sequence::thetah(c, 0);
+    auto h1c = Sequence::thetah(c, 1);
     auto m0 = manual_thetah(m, 0);
     auto m1 = manual_thetah(m, 1);
     BOOST_CHECK_CLOSE(h0, m0, 1e-6);
     BOOST_CHECK_CLOSE(h1, m1, 1e-6);
+    BOOST_CHECK_CLOSE(h0, h0c, 1e-6);
+    BOOST_CHECK_CLOSE(h1, h1c, 1e-6);
 }
 
 BOOST_AUTO_TEST_CASE(test_faywuh)

--- a/test/testClassicSummstats.cc
+++ b/test/testClassicSummstats.cc
@@ -162,6 +162,8 @@ BOOST_AUTO_TEST_CASE(test_thetaw)
         }
     auto manual = S / d;
     BOOST_CHECK_CLOSE(w, manual, 1e-6);
+    auto w2 = Sequence::thetaw(c);
+    BOOST_CHECK_CLOSE(w, w2, 1e-6);
 }
 
 BOOST_AUTO_TEST_CASE(test_thetah)

--- a/test/testClassicSummstats.cc
+++ b/test/testClassicSummstats.cc
@@ -66,11 +66,13 @@ BOOST_FIXTURE_TEST_SUITE(test_classic_stats, dataset)
 BOOST_AUTO_TEST_CASE(test_thetapi)
 {
     auto pi = Sequence::thetapi(m);
-
     auto manual = manual_pi(m);
     // Cannot require equal b/c we aren't doing ops
     // in same order.
     BOOST_CHECK_CLOSE(pi, manual, 1e-6);
+    Sequence::AlleleCountMatrix c(m);
+    auto pi_from_counts = Sequence::thetapi(c);
+    BOOST_CHECK_CLOSE(pi, pi_from_counts, 1e-6);
 }
 
 BOOST_AUTO_TEST_CASE(test_thetapi_with_mising_data)

--- a/test/testClassicSummstatsEmptyVariantMatrix.cc
+++ b/test/testClassicSummstatsEmptyVariantMatrix.cc
@@ -29,57 +29,57 @@ BOOST_FIXTURE_TEST_SUITE(test_classic_stats_with_empty_variant_matrix,
 
 BOOST_AUTO_TEST_CASE(test_thetapi)
 {
-    auto pi = Sequence::thetapi(empty);
+    auto pi = Sequence::thetapi(empty_counts);
     BOOST_REQUIRE_EQUAL(pi, 0.0);
-    pi = Sequence::thetapi(invariant);
+    pi = Sequence::thetapi(invariant_counts);
     BOOST_REQUIRE_EQUAL(pi, 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(test_thetaw)
 {
-    auto tw = Sequence::thetaw(empty);
+    auto tw = Sequence::thetaw(empty_counts);
     BOOST_REQUIRE_EQUAL(tw, 0.0);
-    tw = Sequence::thetaw(invariant);
+    tw = Sequence::thetaw(invariant_counts);
     BOOST_REQUIRE_EQUAL(tw, 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(test_thetah)
 {
-    auto th = Sequence::thetah(empty, 0);
+    auto th = Sequence::thetah(empty_counts, 0);
     BOOST_REQUIRE_EQUAL(th, 0.0);
-    th = Sequence::thetah(invariant, 0);
+    th = Sequence::thetah(invariant_counts, 0);
     BOOST_REQUIRE_EQUAL(th, 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(test_thetal)
 {
-    auto tl = Sequence::thetal(empty, 0);
+    auto tl = Sequence::thetal(empty_counts, 0);
     BOOST_REQUIRE_EQUAL(tl, 0.0);
-    tl = Sequence::thetal(invariant, 0);
+    tl = Sequence::thetal(invariant_counts, 0);
     BOOST_REQUIRE_EQUAL(tl, 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(test_tajd)
 {
-    auto td = Sequence::tajd(empty);
+    auto td = Sequence::tajd(empty_counts);
     BOOST_REQUIRE_EQUAL(std::isnan(td), true);
-    td = Sequence::tajd(invariant);
+    td = Sequence::tajd(invariant_counts);
     BOOST_REQUIRE_EQUAL(std::isnan(td), true);
 }
 
 BOOST_AUTO_TEST_CASE(test_faywuh)
 {
-    auto fwh = Sequence::faywuh(empty, 0);
+    auto fwh = Sequence::faywuh(empty_counts, 0);
     BOOST_REQUIRE_EQUAL(std::isnan(fwh), true);
-    fwh = Sequence::faywuh(invariant, 0);
+    fwh = Sequence::faywuh(invariant_counts, 0);
     BOOST_REQUIRE_EQUAL(std::isnan(fwh), true);
 }
 
 BOOST_AUTO_TEST_CASE(test_hprime)
 {
-    auto hp = Sequence::hprime(empty, 0);
+    auto hp = Sequence::hprime(empty_counts, 0);
     BOOST_REQUIRE_EQUAL(std::isnan(hp), true);
-    hp = Sequence::hprime(invariant, 0);
+    hp = Sequence::hprime(invariant_counts, 0);
     BOOST_REQUIRE_EQUAL(std::isnan(hp), true);
 }
 


### PR DESCRIPTION
Given the emphasis on performance, StateCounts is getting replaced with AlleleCountMatrix.  This makes the overall design very similar to scikit-allel, but with more flexible handling of reference state encoding.