### PR TITLE
Several changes to the nSL code:

### DIFF
--- a/Sequence/bits/col_view_iterator.hpp
+++ b/Sequence/bits/col_view_iterator.hpp
@@ -196,7 +196,7 @@ namespace Sequence
 
     template <typename POINTER>
     inline typename col_view_iterator<POINTER>::difference_type
-    operator-(col_view_iterator<POINTER> i, col_view_iterator<POINTER> j)
+    operator-(col_view_iterator<POINTER>& i, col_view_iterator<POINTER>& j)
     /// Distance between two iterators
     /// \ingroup variantmatrix
     {

--- a/Sequence/bits/col_view_iterator.hpp
+++ b/Sequence/bits/col_view_iterator.hpp
@@ -196,7 +196,8 @@ namespace Sequence
 
     template <typename POINTER>
     inline typename col_view_iterator<POINTER>::difference_type
-    operator-(col_view_iterator<POINTER>& i, col_view_iterator<POINTER>& j)
+    operator-(const col_view_iterator<POINTER>& i,
+              const col_view_iterator<POINTER>& j)
     /// Distance between two iterators
     /// \ingroup variantmatrix
     {
@@ -208,6 +209,6 @@ namespace Sequence
             }
         return (i.offset - j.offset) / i.stride;
     }
-}
+} // namespace Sequence
 
 #endif

--- a/Sequence/summstats.hpp
+++ b/Sequence/summstats.hpp
@@ -15,6 +15,7 @@
 #include "summstats/generic.hpp"
 #include "summstats/classics.hpp"
 #include "summstats/nsl.hpp"
+#include "summstats/nslx.hpp"
 #include "summstats/ld.hpp"
 #include "summstats/garud.hpp"
 

--- a/Sequence/summstats/Makefile.am
+++ b/Sequence/summstats/Makefile.am
@@ -1,5 +1,5 @@
 pkgincludedir=$(prefix)/include/Sequence/summstats
 
 pkginclude_HEADERS = classics.hpp thetapi.hpp thetaw.hpp thetah.hpp thetal.hpp auxillary.hpp nvariablesites.hpp allele_counts.hpp \
-					 util.hpp ld.hpp nsl.hpp garud.hpp generic.hpp \
+					 util.hpp ld.hpp nsl.hpp nslx.hpp garud.hpp generic.hpp \
 					 algorithm.hpp

--- a/Sequence/summstats/Makefile.am
+++ b/Sequence/summstats/Makefile.am
@@ -1,5 +1,5 @@
 pkgincludedir=$(prefix)/include/Sequence/summstats
 
 pkginclude_HEADERS = classics.hpp thetapi.hpp thetaw.hpp thetah.hpp thetal.hpp auxillary.hpp nvariablesites.hpp allele_counts.hpp \
-					 util.hpp ld.hpp nsl.hpp nslx.hpp garud.hpp generic.hpp \
+					 util.hpp ld.hpp nSLiHS.hpp nsl.hpp nslx.hpp garud.hpp generic.hpp \
 					 algorithm.hpp

--- a/Sequence/summstats/Makefile.in
+++ b/Sequence/summstats/Makefile.in
@@ -294,7 +294,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 pkginclude_HEADERS = classics.hpp thetapi.hpp thetaw.hpp thetah.hpp thetal.hpp auxillary.hpp nvariablesites.hpp allele_counts.hpp \
-					 util.hpp ld.hpp nsl.hpp garud.hpp generic.hpp \
+					 util.hpp ld.hpp nsl.hpp nslx.hpp garud.hpp generic.hpp \
 					 algorithm.hpp
 
 all: all-am

--- a/Sequence/summstats/Makefile.in
+++ b/Sequence/summstats/Makefile.in
@@ -294,7 +294,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 pkginclude_HEADERS = classics.hpp thetapi.hpp thetaw.hpp thetah.hpp thetal.hpp auxillary.hpp nvariablesites.hpp allele_counts.hpp \
-					 util.hpp ld.hpp nsl.hpp nslx.hpp garud.hpp generic.hpp \
+					 util.hpp ld.hpp nSLiHS.hpp nsl.hpp nslx.hpp garud.hpp generic.hpp \
 					 algorithm.hpp
 
 all: all-am

--- a/Sequence/summstats/nSLiHS.hpp
+++ b/Sequence/summstats/nSLiHS.hpp
@@ -1,0 +1,28 @@
+#ifndef SEQUENCE_SUMMSTATS_NSLIHS_HPP
+#define SEQUENCE_SUMMSTATS_NSLIHS_HPP
+
+#include <cstdint>
+
+namespace Sequence
+{
+    struct nSLiHS
+    /// Stores the results of nSL and iHS calculations.
+    /// See Sequence::nsl for details.
+    ///
+    /// \note This type is usually forward-declared in other headers,
+    /// meaning this header will need inclusion in relevant translation
+    /// units.
+    ///
+    /// \ingroup popgenanalysis
+    {
+        /// The nSL statistic \cite Ferrer-Admetlla2014-wa
+        double nsl;
+        /// The iHS statistic, calculated according to \cite Ferrer-Admetlla2014-wa
+        double ihs;
+        /// Count of non-reference,
+        /// non-missing allele.
+        std::int32_t core_count;
+    };
+} // namespace Sequence
+
+#endif

--- a/Sequence/summstats/nsl.hpp
+++ b/Sequence/summstats/nsl.hpp
@@ -23,10 +23,38 @@ namespace Sequence
         std::int32_t core_count;
     };
 
+    /*! \brief nSL and iHS statistics
+     * \param m A VariantMatrix
+     * \param core The index of the core site
+     * \param refstate The value of the reference/ancestral allelic state
+     *
+     * \return an nSLiHS object
+     * \ingroup popgenanalysis
+     *
+     * See nSL_from_ms.cc for example
+     *
+     * See \cite Ferrer-Admetlla2014-wa for details.
+     */
     nSLiHS nsl(const VariantMatrix& m, const std::size_t core,
                const std::int8_t refstate);
 
-    std::vector<nSLiHS> nsl(const VariantMatrix& m,
+    /*! \brief nSL and iHS statistics
+     * \param m A VariantMatrix
+     * \param refstate The value of the reference/ancestral allelic state
+     *
+     * \return vector of nSLiHS objects (one for each site)
+     * \ingroup popgenanalysis
+     *
+     * This function differs from the version working 
+     * on a core site in that it uses an efficient matrix-based
+     * method to dynamically update suffix lengths as each 
+     * core site is processed.  The result is a huge runtime
+     * reduction compared to calculating the statistic
+     * for each core site on its own.
+     *
+     * See \cite Ferrer-Admetlla2014-wa for details.
+     */
+        std::vector<nSLiHS> nsl(const VariantMatrix& m,
                             const std::int8_t refstate);
 } // namespace Sequence
 

--- a/Sequence/summstats/nsl.hpp
+++ b/Sequence/summstats/nsl.hpp
@@ -25,8 +25,9 @@ namespace Sequence
 
     nSLiHS nsl(const VariantMatrix& m, const std::size_t core,
                const std::int8_t refstate);
-    std::vector<nSLiHS>
-    all_nsl(const VariantMatrix& m, const std::int8_t refstate);
+
+    std::vector<nSLiHS> nsl(const VariantMatrix& m,
+                            const std::int8_t refstate);
 } // namespace Sequence
 
 #endif

--- a/Sequence/summstats/nsl.hpp
+++ b/Sequence/summstats/nsl.hpp
@@ -6,22 +6,10 @@
 #include <vector>
 #include <cstdint>
 #include <Sequence/VariantMatrix.hpp>
+#include "nSLiHS.hpp"
 
 namespace Sequence
 {
-    struct nSLiHS
-    /// Stores the results of nSL and iHS calculations.
-    /// See Sequence::nsl for details.
-    /// \ingroup popgenanalysis
-    {
-        /// The nSL statistic \cite Ferrer-Admetlla2014-wa
-        double nsl;
-        /// The iHS statistic, calculated according to \cite Ferrer-Admetlla2014-wa
-        double ihs;
-        /// Count of non-reference,
-        /// non-missing allele.
-        std::int32_t core_count;
-    };
 
     /*! \brief nSL and iHS statistics
      * \param m A VariantMatrix

--- a/Sequence/summstats/nsl.hpp
+++ b/Sequence/summstats/nsl.hpp
@@ -3,6 +3,7 @@
 #ifndef SEQUENCE_SUMMSTATS_NSL_HPP__
 #define SEQUENCE_SUMMSTATS_NSL_HPP__
 
+#include <vector>
 #include <cstdint>
 #include <Sequence/VariantMatrix.hpp>
 
@@ -24,6 +25,8 @@ namespace Sequence
 
     nSLiHS nsl(const VariantMatrix& m, const std::size_t core,
                const std::int8_t refstate);
+    std::vector<nSLiHS>
+    all_nsl(const VariantMatrix& m, const std::int8_t refstate);
 } // namespace Sequence
 
 #endif

--- a/Sequence/summstats/nslx.hpp
+++ b/Sequence/summstats/nslx.hpp
@@ -1,0 +1,18 @@
+/// \file Sequence/summstats/nslx.hpp
+/// \brief nSL and iHS
+#ifndef SEQUENCE_SUMMSTATS_NSLX_HPP
+#define SEQUENCE_SUMMSTATS_NSLX_HPP
+
+#include <vector>
+#include <cstdint>
+#include <Sequence/VariantMatrix.hpp>
+
+namespace Sequence
+{
+    struct nSLiHS; //Forward declaration. See Sequence/summstats/nsl.hpp
+
+    std::vector<nSLiHS> nslx(const VariantMatrix& m,
+                             const std::int8_t refstate, const int x);
+} // namespace Sequence
+
+#endif

--- a/Sequence/summstats/nslx.hpp
+++ b/Sequence/summstats/nslx.hpp
@@ -6,11 +6,10 @@
 #include <vector>
 #include <cstdint>
 #include <Sequence/VariantMatrix.hpp>
+#include "nSLiHS.hpp"
 
 namespace Sequence
 {
-    struct nSLiHS; //Forward declaration. See Sequence/summstats/nsl.hpp
-
     std::vector<nSLiHS> nslx(const VariantMatrix& m,
                              const std::int8_t refstate, const int x);
 } // namespace Sequence

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -1,5 +1,6 @@
 check_PROGRAMS= ms_to_VariantMatrix \
 	nSL_from_ms \
+	nSL_vs_nSLx \
 	baseComp valid_dna translateTest \
 	slidingWindow slidingWindow2 PolyTableIterators \
 	ufs \
@@ -7,6 +8,7 @@ check_PROGRAMS= ms_to_VariantMatrix \
 
 ms_to_VariantMatrix_SOURCES=ms_to_VariantMatrix.cc
 nSL_from_ms_SOURCES=nSL_from_ms.cc
+nSL_vs_nSLx_SOURCES=nSL_vs_nSLx.cc
 baseComp_SOURCES=baseComp.cc
 valid_dna_SOURCES=valid_dna.cc
 translateTest_SOURCES=translateTest.cc

--- a/examples/Makefile.in
+++ b/examples/Makefile.in
@@ -88,10 +88,10 @@ POST_UNINSTALL = :
 build_triplet = @build@
 host_triplet = @host@
 check_PROGRAMS = ms_to_VariantMatrix$(EXEEXT) nSL_from_ms$(EXEEXT) \
-	baseComp$(EXEEXT) valid_dna$(EXEEXT) translateTest$(EXEEXT) \
-	slidingWindow$(EXEEXT) slidingWindow2$(EXEEXT) \
-	PolyTableIterators$(EXEEXT) ufs$(EXEEXT) msstats$(EXEEXT) \
-	polySiteVector_test$(EXEEXT)
+	nSL_vs_nSLx$(EXEEXT) baseComp$(EXEEXT) valid_dna$(EXEEXT) \
+	translateTest$(EXEEXT) slidingWindow$(EXEEXT) \
+	slidingWindow2$(EXEEXT) PolyTableIterators$(EXEEXT) \
+	ufs$(EXEEXT) msstats$(EXEEXT) polySiteVector_test$(EXEEXT)
 subdir = examples
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdxx_11.m4 \
@@ -124,6 +124,9 @@ msstats_LDADD = $(LDADD)
 am_nSL_from_ms_OBJECTS = nSL_from_ms.$(OBJEXT)
 nSL_from_ms_OBJECTS = $(am_nSL_from_ms_OBJECTS)
 nSL_from_ms_LDADD = $(LDADD)
+am_nSL_vs_nSLx_OBJECTS = nSL_vs_nSLx.$(OBJEXT)
+nSL_vs_nSLx_OBJECTS = $(am_nSL_vs_nSLx_OBJECTS)
+nSL_vs_nSLx_LDADD = $(LDADD)
 am_polySiteVector_test_OBJECTS = polySiteVector_test.$(OBJEXT)
 polySiteVector_test_OBJECTS = $(am_polySiteVector_test_OBJECTS)
 polySiteVector_test_LDADD = $(LDADD)
@@ -178,14 +181,16 @@ am__v_CXXLD_0 = @echo "  CXXLD   " $@;
 am__v_CXXLD_1 = 
 SOURCES = $(PolyTableIterators_SOURCES) $(baseComp_SOURCES) \
 	$(ms_to_VariantMatrix_SOURCES) $(msstats_SOURCES) \
-	$(nSL_from_ms_SOURCES) $(polySiteVector_test_SOURCES) \
-	$(slidingWindow_SOURCES) $(slidingWindow2_SOURCES) \
-	$(translateTest_SOURCES) $(ufs_SOURCES) $(valid_dna_SOURCES)
+	$(nSL_from_ms_SOURCES) $(nSL_vs_nSLx_SOURCES) \
+	$(polySiteVector_test_SOURCES) $(slidingWindow_SOURCES) \
+	$(slidingWindow2_SOURCES) $(translateTest_SOURCES) \
+	$(ufs_SOURCES) $(valid_dna_SOURCES)
 DIST_SOURCES = $(PolyTableIterators_SOURCES) $(baseComp_SOURCES) \
 	$(ms_to_VariantMatrix_SOURCES) $(msstats_SOURCES) \
-	$(nSL_from_ms_SOURCES) $(polySiteVector_test_SOURCES) \
-	$(slidingWindow_SOURCES) $(slidingWindow2_SOURCES) \
-	$(translateTest_SOURCES) $(ufs_SOURCES) $(valid_dna_SOURCES)
+	$(nSL_from_ms_SOURCES) $(nSL_vs_nSLx_SOURCES) \
+	$(polySiteVector_test_SOURCES) $(slidingWindow_SOURCES) \
+	$(slidingWindow2_SOURCES) $(translateTest_SOURCES) \
+	$(ufs_SOURCES) $(valid_dna_SOURCES)
 am__can_run_installinfo = \
   case $$AM_UPDATE_INFO_DIR in \
     n|no|NO) false;; \
@@ -348,6 +353,7 @@ top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 ms_to_VariantMatrix_SOURCES = ms_to_VariantMatrix.cc
 nSL_from_ms_SOURCES = nSL_from_ms.cc
+nSL_vs_nSLx_SOURCES = nSL_vs_nSLx.cc
 baseComp_SOURCES = baseComp.cc
 valid_dna_SOURCES = valid_dna.cc
 translateTest_SOURCES = translateTest.cc
@@ -423,6 +429,10 @@ nSL_from_ms$(EXEEXT): $(nSL_from_ms_OBJECTS) $(nSL_from_ms_DEPENDENCIES) $(EXTRA
 	@rm -f nSL_from_ms$(EXEEXT)
 	$(AM_V_CXXLD)$(CXXLINK) $(nSL_from_ms_OBJECTS) $(nSL_from_ms_LDADD) $(LIBS)
 
+nSL_vs_nSLx$(EXEEXT): $(nSL_vs_nSLx_OBJECTS) $(nSL_vs_nSLx_DEPENDENCIES) $(EXTRA_nSL_vs_nSLx_DEPENDENCIES) 
+	@rm -f nSL_vs_nSLx$(EXEEXT)
+	$(AM_V_CXXLD)$(CXXLINK) $(nSL_vs_nSLx_OBJECTS) $(nSL_vs_nSLx_LDADD) $(LIBS)
+
 polySiteVector_test$(EXEEXT): $(polySiteVector_test_OBJECTS) $(polySiteVector_test_DEPENDENCIES) $(EXTRA_polySiteVector_test_DEPENDENCIES) 
 	@rm -f polySiteVector_test$(EXEEXT)
 	$(AM_V_CXXLD)$(CXXLINK) $(polySiteVector_test_OBJECTS) $(polySiteVector_test_LDADD) $(LIBS)
@@ -458,6 +468,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ms_to_VariantMatrix.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/msstats.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/nSL_from_ms.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/nSL_vs_nSLx.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/polySiteVector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/slidingWindow.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/slidingWindow2.Po@am__quote@

--- a/examples/nSL_from_ms.cc
+++ b/examples/nSL_from_ms.cc
@@ -11,7 +11,7 @@ int
 main(int argc, char** argv)
 {
     auto vm = Sequence::from_msformat(std::cin);
-    auto nsl_stats = Sequence::all_nsl(vm, 0);
+    auto nsl_stats = Sequence::nsl(vm, 0);
     assert(nsl_stats.size() == vm.nsites);
     for (std::size_t i = 0; i < vm.nsites; ++i)
         {

--- a/examples/nSL_from_ms.cc
+++ b/examples/nSL_from_ms.cc
@@ -1,6 +1,7 @@
 /*! \include nSL_from_ms.cc */
 #include <cmath>
 #include <iostream>
+#include <cassert>
 #include <Sequence/VariantMatrix.hpp>
 #include <Sequence/VariantMatrixViews.hpp>
 #include <Sequence/variant_matrix/msformat.hpp>
@@ -10,13 +11,21 @@ int
 main(int argc, char** argv)
 {
     auto vm = Sequence::from_msformat(std::cin);
+    auto nsl_stats = Sequence::all_nsl(vm, 0);
+    assert(nsl_stats.size() == vm.nsites);
     for (std::size_t i = 0; i < vm.nsites; ++i)
         {
             auto n = Sequence::nsl(vm, i, 0);
             if (!std::isnan(n.nsl))
                 {
                     std::cout << vm.positions[i] << ' ' << n.nsl << ' '
-                              << n.ihs << ' ' << n.core_count << '\n';
+                              << n.ihs << ' ' << n.core_count << ' '
+                              << nsl_stats[i].nsl << ' ' << nsl_stats[i].ihs
+                              << ' ' << nsl_stats[i].core_count << '\n';
+                }
+            else
+                {
+                    assert(std::isnan(nsl_stats[i].nsl));
                 }
         }
 }

--- a/examples/nSL_vs_nSLx.cc
+++ b/examples/nSL_vs_nSLx.cc
@@ -1,0 +1,19 @@
+/*! \include nSL_from_ms.cc */
+#include <cmath>
+#include <iostream>
+#include <cassert>
+#include <Sequence/VariantMatrix.hpp>
+#include <Sequence/VariantMatrixViews.hpp>
+#include <Sequence/variant_matrix/msformat.hpp>
+#include <Sequence/summstats/nsl.hpp>
+#include <Sequence/summstats/nslx.hpp>
+
+int
+main(int argc, char** argv)
+{
+    int x = std::atoi(argv[1]);
+    auto vm = Sequence::from_msformat(std::cin);
+    auto nsl_stats = Sequence::nslx(vm, 0, x);
+    for(auto & s : nsl_stats){std::cout << s.nsl << ' ' << s.ihs << ' ' << s.core_count << '\n'; }
+}
+

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -61,6 +61,7 @@ libsequence_la_SOURCES=  Grantham.cc\
 	summstats/ld.cc \
 	summstats/rmin.cc \
 	summstats/nsl.cc \
+	summstats/nslx.cc \
 	summstats/garud.cc \
 	summstats/generic.cc \
 	summstats/auxillary.cc

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -156,7 +156,8 @@ am_libsequence_la_OBJECTS = Grantham.lo PathwayHelper.lo \
 	summstats/hprime.lo summstats/nvariablesites.lo \
 	summstats/allele_counts.lo summstats/haplotype_statistics.lo \
 	summstats/ld.lo summstats/rmin.lo summstats/nsl.lo \
-	summstats/garud.lo summstats/generic.lo summstats/auxillary.lo
+	summstats/nslx.lo summstats/garud.lo summstats/generic.lo \
+	summstats/auxillary.lo
 libsequence_la_OBJECTS = $(am_libsequence_la_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
@@ -411,6 +412,7 @@ libsequence_la_SOURCES = Grantham.cc\
 	summstats/ld.cc \
 	summstats/rmin.cc \
 	summstats/nsl.cc \
+	summstats/nslx.cc \
 	summstats/garud.cc \
 	summstats/generic.cc \
 	summstats/auxillary.cc
@@ -568,6 +570,8 @@ summstats/rmin.lo: summstats/$(am__dirstamp) \
 	summstats/$(DEPDIR)/$(am__dirstamp)
 summstats/nsl.lo: summstats/$(am__dirstamp) \
 	summstats/$(DEPDIR)/$(am__dirstamp)
+summstats/nslx.lo: summstats/$(am__dirstamp) \
+	summstats/$(DEPDIR)/$(am__dirstamp)
 summstats/garud.lo: summstats/$(am__dirstamp) \
 	summstats/$(DEPDIR)/$(am__dirstamp)
 summstats/generic.lo: summstats/$(am__dirstamp) \
@@ -695,6 +699,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@summstats/$(DEPDIR)/hprime.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@summstats/$(DEPDIR)/ld.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@summstats/$(DEPDIR)/nsl.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@summstats/$(DEPDIR)/nslx.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@summstats/$(DEPDIR)/nvariablesites.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@summstats/$(DEPDIR)/rmin.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@summstats/$(DEPDIR)/tajd.Plo@am__quote@

--- a/src/summstats/nsl.cc
+++ b/src/summstats/nsl.cc
@@ -100,7 +100,7 @@ namespace Sequence
                 auto sample_i = get_ConstColView(m, i);
                 for (std::size_t j = i + 1; j < m.nsam; ++j)
                     {
-                        if (core_view[i] == core_view[j])
+                        if (core_view[i] == core_view[j] && core_view[i] >= 0)
                             {
                                 auto sample_j = get_ConstColView(m, j);
                                 //Find where samples i and j differ
@@ -135,6 +135,16 @@ namespace Sequence
                        std::log(iHS_num) - std::log(iHS_den), nonrefcount };
     }
 
+    // TODO: A further optimization may be possible.
+    // If you move the iteration over cores to the innermost
+    // loop, then you can keep recording the same value
+    // up until you hit the right position.  The
+    // reason is that you know that homozygosity
+    // extends to the right and all you have to
+    // check for is ancestral, derived, or missing.
+    // This change would reduce the extra n^2 memory
+    // required but it would introduce an O(nsites)
+    // traversal for all sequence pairs.
     std::vector<nSLiHS>
     all_nsl(const VariantMatrix& m, const std::int8_t refstate)
     {
@@ -163,7 +173,8 @@ namespace Sequence
                         auto sample_i = get_ConstColView(m, i);
                         for (std::size_t j = i + 1; j < m.nsam; ++j)
                             {
-                                if (core_view[i] == core_view[j])
+                                if (core_view[i] == core_view[j]
+                                    && core_view[i] >= 0)
                                     {
                                         auto sample_j = get_ConstColView(m, j);
                                         std::size_t lindex = j * m.nsam + i;

--- a/src/summstats/nsl.cc
+++ b/src/summstats/nsl.cc
@@ -1,4 +1,4 @@
-#include <iostream>
+#include <vector>
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
@@ -11,12 +11,12 @@ namespace
 {
     std::int64_t
     get_left(const Sequence::ConstColView& sample_i,
-             const Sequence::ConstColView& sample_j, const std::size_t core)
+             const Sequence::ConstColView& sample_j, const std::size_t core,
+             std::int64_t minleft)
     {
         std::int64_t left = static_cast<std::int64_t>(core) - 1;
         std::size_t left_index;
-
-        while (left >= 0)
+        while (left >= minleft)
             {
                 left_index = static_cast<std::size_t>(left);
                 if (sample_i[left_index] >= 0 && sample_j[left_index] >= 0
@@ -63,8 +63,8 @@ namespace
                 nsl_values[index] += static_cast<double>(right - left);
                 //TODO: check if we need to add one?
                 ihs_values[index]
-                    += positions[static_cast<std::size_t>(left)]
-                       - positions[static_cast<std::size_t>(right)];
+                    += positions[static_cast<std::size_t>(right)]
+                       - positions[static_cast<std::size_t>(left)];
                 counts[index]++;
             }
     }
@@ -104,22 +104,28 @@ namespace Sequence
                             {
                                 auto sample_j = get_ConstColView(m, j);
                                 //Find where samples i and j differ
-                                auto left = get_left(sample_i, sample_j, core);
-                                auto right = get_right(
-                                    sample_i, sample_j, core,
-                                    static_cast<std::int64_t>(m.nsites));
-                                update_counts(nsl_values, ihs_values, counts,
-                                              m.nsites, m.positions,
-                                              static_cast<std::size_t>(
-                                                  core_view[i] == refstate),
-                                              left, right);
+                                auto left
+                                    = get_left(sample_i, sample_j, core, 0);
+                                if (left >= 0)
+                                    {
+                                        auto right = get_right(
+                                            sample_i, sample_j, core,
+                                            static_cast<std::int64_t>(
+                                                m.nsites));
+                                        update_counts(
+                                            nsl_values, ihs_values, counts,
+                                            m.nsites, m.positions,
+                                            static_cast<std::size_t>(
+                                                core_view[i] == refstate),
+                                            left, right);
+                                    }
                             }
                     }
             }
         double nSL_den = nsl_values[0] / static_cast<double>(counts[0]);
         double nSL_num = nsl_values[1] / static_cast<double>(counts[1]);
-        double iHS_den = nsl_values[0] / static_cast<double>(counts[0]);
-        double iHS_num = nsl_values[1] / static_cast<double>(counts[1]);
+        double iHS_den = ihs_values[0] / static_cast<double>(counts[0]);
+        double iHS_num = ihs_values[1] / static_cast<double>(counts[1]);
         auto nonrefcount = static_cast<std::int32_t>(
             std::count_if(core_view.begin(), core_view.end(),
                           [refstate](const std::int8_t i) {
@@ -129,12 +135,125 @@ namespace Sequence
                        std::log(iHS_num) - std::log(iHS_den), nonrefcount };
     }
 
+    std::vector<nSLiHS>
+    all_nsl(const VariantMatrix& m, const std::int8_t refstate)
+    {
+        std::vector<nSLiHS> rv;
+        if (m.nsam == 0)
+            {
+                return rv;
+            }
+        rv.reserve(m.nsites);
+
+        // A matrix keeping track of the
+        // index where sample i,j last differed.
+        // The lower left corresponds to left edges,
+        // and the upper right are the right edges.
+        // -1 mean unevaluated.
+        std::vector<std::int64_t> edges(m.nsam * m.nsam, -1);
+        for (std::size_t core = 0; core < m.nsites; ++core)
+            {
+                auto core_view = get_ConstRowView(m, core);
+                double nsl_values[2] = { 0, 0 };
+                double ihs_values[2] = { 0, 0 };
+                //Count sample size for non-ref and ref alleles at core site contributing to nSL
+                int counts[2] = { 0, 0 };
+                for (std::size_t i = 0; i < m.nsam - 1; ++i)
+                    {
+                        auto sample_i = get_ConstColView(m, i);
+                        for (std::size_t j = i + 1; j < m.nsam; ++j)
+                            {
+                                if (core_view[i] == core_view[j])
+                                    {
+                                        auto sample_j = get_ConstColView(m, j);
+                                        std::size_t lindex = j * m.nsam + i;
+                                        std::size_t rindex = i * m.nsam + j;
+                                        std::int64_t lstart
+                                            = (edges[lindex] == -1)
+                                                  ? 0
+                                                  : edges[lindex];
+                                        std::int64_t rstart
+                                            = (edges[rindex] == -1)
+                                                  ? static_cast<std::int64_t>(
+                                                        m.nsites)
+                                                  : edges[rindex];
+                                        if (rstart <= core)
+                                            {
+                                                rstart = m.nsites;
+                                            }
+                                        auto left
+                                            = (edges[lindex] == -1)
+                                                  ? get_left(sample_i,
+                                                             sample_j, core,
+                                                             lstart)
+                                                  : lstart;
+                                        if (left >= 0)
+                                            {
+                                                if (rstart < m.nsites)
+                                                    {
+                                                        update_counts(
+                                                            nsl_values,
+                                                            ihs_values, counts,
+                                                            m.nsites,
+                                                            m.positions,
+                                                            static_cast<
+                                                                std::size_t>(
+                                                                core_view[i]
+                                                                == refstate),
+                                                            left, rstart);
+                                                    }
+                                                else
+                                                    {
+                                                        auto right = get_right(
+                                                            sample_i, sample_j,
+                                                            core, rstart);
+                                                        update_counts(
+                                                            nsl_values,
+                                                            ihs_values, counts,
+                                                            m.nsites,
+                                                            m.positions,
+                                                            static_cast<
+                                                                std::size_t>(
+                                                                core_view[i]
+                                                                == refstate),
+                                                            left, right);
+                                                        edges[rindex] = right;
+                                                    }
+                                            }
+                                        edges[lindex] = left;
+                                    }
+                                else //The sites differ, making this a new left edge
+                                    {
+                                        edges[j * m.nsam + i] = core;
+                                    }
+                            }
+                    }
+                double nSL_den
+                    = nsl_values[0] / static_cast<double>(counts[0]);
+                double nSL_num
+                    = nsl_values[1] / static_cast<double>(counts[1]);
+                double iHS_den
+                    = ihs_values[0] / static_cast<double>(counts[0]);
+                double iHS_num
+                    = ihs_values[1] / static_cast<double>(counts[1]);
+                auto nonrefcount = static_cast<std::int32_t>(
+                    std::count_if(core_view.begin(), core_view.end(),
+                                  [refstate](const std::int8_t i) {
+                                      return i >= 0 && i != refstate;
+                                  }));
+                rv.emplace_back(nSLiHS{ std::log(nSL_num) - std::log(nSL_den),
+                                        std::log(iHS_num) - std::log(iHS_den),
+                                        nonrefcount });
+            }
+        return rv;
+    }
+
     nSLiHS
     nslx(const VariantMatrix& m, const std::size_t core,
-        const std::int8_t refstate, const int x)
-	{
-		//Need to get indexes of all x-tons.
-		//Then, if two seqs differ at an x-ton,
-		//the stats get updated.
-	}
+         const std::int8_t refstate, const int x)
+    {
+        //Need to get indexes of all x-tons.
+        //Then, if two seqs differ at an x-ton,
+        //the stats get updated.
+    }
 } // namespace Sequence

--- a/src/summstats/nsl.cc
+++ b/src/summstats/nsl.cc
@@ -115,7 +115,7 @@ namespace
             }
         else
             {
-                edges[lindex] = core;
+                edges[lindex] = static_cast<std::int64_t>(core);
             }
         return rv;
     }

--- a/src/summstats/nsl.cc
+++ b/src/summstats/nsl.cc
@@ -5,6 +5,7 @@
 #include <Sequence/VariantMatrix.hpp>
 #include <Sequence/VariantMatrixViews.hpp>
 #include <Sequence/summstats/nsl.hpp>
+#include "nsl_common.hpp"
 
 /// \example nSL_from_ms.cc
 namespace
@@ -49,26 +50,6 @@ namespace
                 ++state_j;
             }
         return right;
-    }
-
-    void
-    update_counts(double nsl_values[2], double ihs_values[2], int counts[2],
-                  const std::size_t nsites,
-                  const std::vector<double>& positions,
-                  const std::size_t index, const std::int64_t left,
-                  const std::int64_t right)
-    {
-        if (left >= 0 && static_cast<std::size_t>(right) < nsites)
-            //Then there are SNPs differentiating
-            //i and j within the region
-            {
-                nsl_values[index] += static_cast<double>(right - left);
-                //TODO: check if we need to add one?
-                ihs_values[index]
-                    += positions[static_cast<std::size_t>(right)]
-                       - positions[static_cast<std::size_t>(left)];
-                counts[index]++;
-            }
     }
 
     inline bool
@@ -119,116 +100,7 @@ namespace
             }
         return rv;
     }
-
-    inline bool
-    is_xton(const std::vector<std::int64_t>& xtons, const std::int64_t test)
-    {
-        return std::binary_search(xtons.begin(), xtons.end(), test);
-    }
-
-    inline bool
-    update_edge_matrix(const Sequence::VariantMatrix& m,
-                       const std::vector<std::int64_t>& xtons,
-                       const std::pair<std::int64_t, std::int64_t> flanks,
-                       const Sequence::ConstRowView& core_view,
-                       const Sequence::ConstColView& hapi,
-                       std::vector<std::int64_t>& edges,
-                       const std::size_t core, const std::size_t i,
-                       const std::size_t j)
-    // edge updating for nslx
-    // precondition: !xtons.empty()
-    {
-        bool rv = false;
-        std::size_t lindex = j * m.nsam + i;
-        if (core_view[i] == core_view[j] && !(core_view[i] < 0))
-            {
-                auto hapj = get_ConstColView(m, j);
-                std::int64_t left_edge = edges[lindex];
-                if (left_edge == -1)
-                    {
-                        //Variant 0 can only break homozygosity
-                        //run if it is an xton
-                        if (xtons.front() == 0 && hapi[0] != hapj[0])
-                            {
-                                left_edge = 0;
-                                edges[lindex] = left_edge;
-                                rv = true;
-                            }
-                    }
-                if (left_edge >= 0)
-                    {
-                        std::size_t rindex = i * m.nsam + j;
-                        std::int64_t right_edge = edges[rindex];
-                        if (right_edge == -1
-                            || static_cast<std::size_t>(right_edge) <= core)
-                            {
-                                rv = false;
-                                for (auto r = flanks.second; r < xtons.size();
-                                     ++r)
-                                    {
-                                        if (hapi[r] != hapj[r]
-                                            && !(hapi[r] < 0))
-                                            {
-                                                rv = true;
-                                                edges[rindex] = r;
-                                            }
-                                    }
-                            }
-                    }
-            }
-        else if (is_xton(xtons, core))
-            {
-                edges[lindex] = core;
-            }
-        return rv;
-    }
-
-    inline Sequence::nSLiHS
-    get_stat(const Sequence::ConstRowView& core_view,
-             const std::int8_t refstate, const double nsl_values[2],
-             const double ihs_values[2], const int counts[2])
-    {
-
-        double nSL_den = nsl_values[0] / static_cast<double>(counts[0]);
-        double nSL_num = nsl_values[1] / static_cast<double>(counts[1]);
-        double iHS_den = ihs_values[0] / static_cast<double>(counts[0]);
-        double iHS_num = ihs_values[1] / static_cast<double>(counts[1]);
-        auto nonrefcount = static_cast<std::int32_t>(
-            std::count_if(core_view.begin(), core_view.end(),
-                          [refstate](const std::int8_t i) {
-                              return i >= 0 && i != refstate;
-                          }));
-        return Sequence::nSLiHS{ std::log(nSL_num) - std::log(nSL_den),
-                                 std::log(iHS_num) - std::log(iHS_den),
-                                 nonrefcount };
-    }
-
-    std::pair<std::int64_t, std::int64_t>
-    get_flanking_xtons(const std::vector<int64_t>& xtons,
-                       const std::size_t core)
-    {
-        auto left_xton = std::upper_bound(
-            xtons.rbegin(), xtons.rend(), core,
-            [](const std::int64_t element, const std::size_t value) {
-                return element > value;
-            });
-        if (left_xton == xtons.rend())
-            {
-                return std::make_pair(-1, -1);
-            }
-        auto right_xton = std::upper_bound(
-            left_xton.base(), xtons.end(), core,
-            [](const std::int64_t element, const std::size_t value) {
-                return element < value;
-            });
-        if (right_xton == xtons.end())
-            {
-                return std::make_pair(-1, -1);
-            }
-        return std::make_pair(std::distance(xtons.begin(), left_xton.base()),
-                              std::distance(xtons.begin(), right_xton));
-    }
-} // namespace
+}
 
 namespace Sequence
 {
@@ -326,74 +198,6 @@ namespace Sequence
                                             static_cast<std::size_t>(
                                                 core_view[i] == refstate),
                                             edges[lindex], edges[rindex]);
-                                    }
-                            }
-                    }
-                rv.emplace_back(get_stat(core_view, refstate, nsl_values,
-                                         ihs_values, counts));
-            }
-        return rv;
-    }
-
-    std::vector<nSLiHS>
-    nslx(const VariantMatrix& m, const std::int8_t refstate, const int x)
-    {
-        //Need to get indexes of all x-tons.
-        //Then, if two seqs differ at an x-ton,
-        //the stats get updated.
-        std::vector<std::int64_t> xtons;
-        for (std::int64_t i = 0; i < static_cast<std::int64_t>(m.nsites); ++i)
-            {
-                auto r = get_ConstRowView(m, static_cast<std::size_t>(i));
-                auto nonref = std::count_if(
-                    r.begin(), r.end(), [refstate](const std::int8_t a) {
-                        return a != refstate && !(a < 0);
-                    });
-                if (nonref == x)
-                    {
-                        xtons.push_back(i);
-                    }
-            }
-        std::vector<nSLiHS> rv;
-        if (xtons.empty() || !m.nsam || !m.nsites)
-            {
-                return rv;
-            }
-
-        std::vector<std::int64_t> edges(m.nsam * m.nsam, -1);
-        std::size_t lindex, rindex;
-        for (std::size_t core = 0; core < m.nsites; ++core)
-            {
-                auto core_view = get_ConstRowView(m, core);
-                // Doing any work requires the existence
-                // of x-tons left and right of core
-                auto flanks = get_flanking_xtons(xtons, core);
-                double nsl_values[2] = { 0, 0 };
-                double ihs_values[2] = { 0, 0 };
-                int counts[2] = { 0, 0 };
-                if (flanks.first != -1)
-                    {
-                        for (std::size_t i = 0; i < m.nsam - 1; ++i)
-                            {
-                                auto sample_i = get_ConstColView(m, i);
-                                for (std::size_t j = i + 1; j < m.nsam; ++j)
-                                    {
-                                        if (update_edge_matrix(
-                                                m, xtons, flanks, core_view,
-                                                sample_i, edges, core, i, j))
-                                            {
-                                                lindex = j * m.nsam + i;
-                                                rindex = i * m.nsam + j;
-                                                update_counts(
-                                                    nsl_values, ihs_values,
-                                                    counts, m.nsites,
-                                                    m.positions,
-                                                    static_cast<std::size_t>(
-                                                        core_view[i]
-                                                        == refstate),
-                                                    edges[lindex],
-                                                    edges[rindex]);
-                                            }
                                     }
                             }
                     }

--- a/src/summstats/nsl.cc
+++ b/src/summstats/nsl.cc
@@ -183,16 +183,6 @@ namespace Sequence
         return get_stat(core_view, refstate, nsl_values, ihs_values, counts);
     }
 
-    // TODO: A further optimization may be possible.
-    // If you move the iteration over cores to the innermost
-    // loop, then you can keep recording the same value
-    // up until you hit the right position.  The
-    // reason is that you know that homozygosity
-    // extends to the right and all you have to
-    // check for is ancestral, derived, or missing.
-    // This change would reduce the extra n^2 memory
-    // required but it would introduce an O(nsites)
-    // traversal for all sequence pairs.
     std::vector<nSLiHS>
     all_nsl(const VariantMatrix& m, const std::int8_t refstate)
     {

--- a/src/summstats/nsl.cc
+++ b/src/summstats/nsl.cc
@@ -305,27 +305,18 @@ namespace Sequence
                 // Doing any work requires the existence
                 // of x-tons left and right of core
                 auto flanks = get_flanking_xtons(xtons, core);
+                double nsl_values[2] = { 0, 0 };
+                double ihs_values[2] = { 0, 0 };
+                int counts[2] = { 0, 0 };
                 if (flanks.first != -1)
                     {
                         for (std::size_t i = 0; i < m.nsam - 1; ++i)
                             {
                                 auto sample_i = get_ConstColView(m, i);
-                                for (std::size_t j = i + 1; i < m.nsam; ++j)
-                                    {
-                                        lindex = j * m.nsam + i;
-                                        rindex = i * m.nsam + j;
-                                        if (core_view[i] != core_view[j]
-                                            && !(core_view[i] < 0))
-                                            {
-                                            }
-                                        else
-                                            {
-                                                edges[lindex] = static_cast<
-                                                    std::int64_t>(core);
-                                            }
-                                    }
                             }
                     }
+                rv.emplace_back(get_stat(core_view, refstate, nsl_values,
+                                         ihs_values, counts));
             }
         return rv;
     }

--- a/src/summstats/nsl.cc
+++ b/src/summstats/nsl.cc
@@ -54,7 +54,7 @@ namespace
                        std::vector<std::int64_t>& edges,
                        const std::size_t core, const std::size_t i,
                        const std::size_t j)
-    // For the all_nsl operations, this function keeps track
+    // For the nsl operations, this function keeps track
     // of the left/right boundaries of haplotype homozygosity
     // as core moves through the sample:
     {
@@ -148,7 +148,7 @@ namespace Sequence
     }
 
     std::vector<nSLiHS>
-    all_nsl(const VariantMatrix& m, const std::int8_t refstate)
+    nsl(const VariantMatrix& m, const std::int8_t refstate)
     {
         std::vector<nSLiHS> rv;
         if (m.nsam == 0)

--- a/src/summstats/nsl.cc
+++ b/src/summstats/nsl.cc
@@ -86,8 +86,11 @@ namespace
         std::int64_t left_edge = edges[lindex];
         if (left_edge == -1)
             {
-                left_edge = get_left(hapi, hapj, core, 0);
-                edges[lindex] = left_edge;
+                if (hapi[0] != hapj[0])
+                    {
+                        left_edge = 0;
+                        edges[lindex] = left_edge;
+                    }
             }
         if (left_edge >= 0)
             {

--- a/src/summstats/nsl.cc
+++ b/src/summstats/nsl.cc
@@ -99,18 +99,6 @@ namespace Sequence
     nSLiHS
     nsl(const VariantMatrix& m, const std::size_t core,
         const std::int8_t refstate)
-    /*! \brief nSL and iHS statistics
-     * \param m A VariantMatrix
-     * \param core The index of the core site
-     * \param refstate The value of the reference/ancestral allelic state
-     *
-     * \return an nSLiHS object
-     * \ingroup popgenanalysis
-     *
-     * See nSL_from_ms.cc for example
-     *
-     * See \cite Ferrer-Admetlla2014-wa for details.
-     */
     {
         auto core_view = get_ConstRowView(m, core);
         // Keep track of distances from core site

--- a/src/summstats/nsl_common.hpp
+++ b/src/summstats/nsl_common.hpp
@@ -1,0 +1,57 @@
+#ifndef SEQUENCE_SUMMSTATS_NSL_COMMON_HPP
+#define SEQUENCE_SUMMSTATS_NSL_COMMON_HPP
+
+// These functions are not exported.
+// They are used internally.
+
+#include <cstdint>
+#include <vector>
+#include <algorithm>
+#include <cmath>
+#include <Sequence/summstats/nsl.hpp>
+#include <Sequence/VariantMatrixViews.hpp>
+
+namespace Sequence
+{
+    static void
+    update_counts(double nsl_values[2], double ihs_values[2], int counts[2],
+                  const std::size_t nsites,
+                  const std::vector<double>& positions,
+                  const std::size_t index, const std::int64_t left,
+                  const std::int64_t right)
+    {
+        if (left >= 0 && static_cast<std::size_t>(right) < nsites)
+            //Then there are SNPs differentiating
+            //i and j within the region
+            {
+                nsl_values[index] += static_cast<double>(right - left);
+                //TODO: check if we need to add one?
+                ihs_values[index]
+                    += positions[static_cast<std::size_t>(right)]
+                       - positions[static_cast<std::size_t>(left)];
+                counts[index]++;
+            }
+    }
+
+    inline nSLiHS
+    get_stat(const ConstRowView& core_view, const std::int8_t refstate,
+             const double nsl_values[2], const double ihs_values[2],
+             const int counts[2])
+    {
+
+        double nSL_den = nsl_values[0] / static_cast<double>(counts[0]);
+        double nSL_num = nsl_values[1] / static_cast<double>(counts[1]);
+        double iHS_den = ihs_values[0] / static_cast<double>(counts[0]);
+        double iHS_num = ihs_values[1] / static_cast<double>(counts[1]);
+        auto nonrefcount = static_cast<std::int32_t>(
+            std::count_if(core_view.begin(), core_view.end(),
+                          [refstate](const std::int8_t i) {
+                              return i >= 0 && i != refstate;
+                          }));
+        return nSLiHS{ std::log(nSL_num) - std::log(nSL_den),
+                       std::log(iHS_num) - std::log(iHS_den), nonrefcount };
+    }
+
+} // namespace Sequence
+
+#endif

--- a/src/summstats/nsl_common.hpp
+++ b/src/summstats/nsl_common.hpp
@@ -8,7 +8,7 @@
 #include <vector>
 #include <algorithm>
 #include <cmath>
-#include <Sequence/summstats/nsl.hpp>
+#include <Sequence/summstats/nSLiHS.hpp>
 #include <Sequence/VariantMatrixViews.hpp>
 
 namespace Sequence

--- a/src/summstats/nslx.cc
+++ b/src/summstats/nslx.cc
@@ -1,0 +1,166 @@
+#include <algorithm>
+#include <Sequence/summstats/nsl.hpp>
+#include <Sequence/VariantMatrixViews.hpp>
+#include "nsl_common.hpp"
+
+namespace
+{
+    inline bool
+    is_xton(const std::vector<std::int64_t>& xtons, const std::int64_t test)
+    {
+        return std::binary_search(xtons.begin(), xtons.end(), test);
+    }
+
+    inline bool
+    update_edge_matrix(const Sequence::VariantMatrix& m,
+                       const std::vector<std::int64_t>& xtons,
+                       const std::pair<std::int64_t, std::int64_t> flanks,
+                       const Sequence::ConstRowView& core_view,
+                       const Sequence::ConstColView& hapi,
+                       std::vector<std::int64_t>& edges,
+                       const std::size_t core, const std::size_t i,
+                       const std::size_t j)
+    // edge updating for nslx
+    // precondition: !xtons.empty()
+    {
+        bool rv = false;
+        std::size_t lindex = j * m.nsam + i;
+        if (core_view[i] == core_view[j] && !(core_view[i] < 0))
+            {
+                auto hapj = get_ConstColView(m, j);
+                std::int64_t left_edge = edges[lindex];
+                if (left_edge == -1)
+                    {
+                        //Variant 0 can only break homozygosity
+                        //run if it is an xton
+                        if (xtons.front() == 0 && hapi[0] != hapj[0])
+                            {
+                                left_edge = 0;
+                                edges[lindex] = left_edge;
+                                rv = true;
+                            }
+                    }
+                if (left_edge >= 0)
+                    {
+                        std::size_t rindex = i * m.nsam + j;
+                        std::int64_t right_edge = edges[rindex];
+                        if (right_edge == -1
+                            || static_cast<std::size_t>(right_edge) <= core)
+                            {
+                                rv = false;
+                                for (auto r = flanks.second; r < xtons.size();
+                                     ++r)
+                                    {
+                                        if (hapi[r] != hapj[r]
+                                            && !(hapi[r] < 0))
+                                            {
+                                                rv = true;
+                                                edges[rindex] = r;
+                                            }
+                                    }
+                            }
+                    }
+            }
+        else if (is_xton(xtons, core))
+            {
+                edges[lindex] = core;
+            }
+        return rv;
+    }
+    std::pair<std::int64_t, std::int64_t>
+    get_flanking_xtons(const std::vector<int64_t>& xtons,
+                       const std::size_t core)
+    {
+        auto left_xton = std::upper_bound(
+            xtons.rbegin(), xtons.rend(), core,
+            [](const std::int64_t element, const std::size_t value) {
+                return element > value;
+            });
+        if (left_xton == xtons.rend())
+            {
+                return std::make_pair(-1, -1);
+            }
+        auto right_xton = std::upper_bound(
+            left_xton.base(), xtons.end(), core,
+            [](const std::int64_t element, const std::size_t value) {
+                return element < value;
+            });
+        if (right_xton == xtons.end())
+            {
+                return std::make_pair(-1, -1);
+            }
+        return std::make_pair(std::distance(xtons.begin(), left_xton.base()),
+                              std::distance(xtons.begin(), right_xton));
+    }
+} // namespace
+
+namespace Sequence
+{
+    std::vector<nSLiHS>
+    nslx(const VariantMatrix& m, const std::int8_t refstate, const int x)
+    {
+        //Need to get indexes of all x-tons.
+        //Then, if two seqs differ at an x-ton,
+        //the stats get updated.
+        std::vector<std::int64_t> xtons;
+        for (std::int64_t i = 0; i < static_cast<std::int64_t>(m.nsites); ++i)
+            {
+                auto r = get_ConstRowView(m, static_cast<std::size_t>(i));
+                auto nonref = std::count_if(
+                    r.begin(), r.end(), [refstate](const std::int8_t a) {
+                        return a != refstate && !(a < 0);
+                    });
+                if (nonref == x)
+                    {
+                        xtons.push_back(i);
+                    }
+            }
+        std::vector<nSLiHS> rv;
+        if (xtons.empty() || !m.nsam || !m.nsites)
+            {
+                return rv;
+            }
+
+        std::vector<std::int64_t> edges(m.nsam * m.nsam, -1);
+        std::size_t lindex, rindex;
+        for (std::size_t core = 0; core < m.nsites; ++core)
+            {
+                auto core_view = get_ConstRowView(m, core);
+                // Doing any work requires the existence
+                // of x-tons left and right of core
+                auto flanks = get_flanking_xtons(xtons, core);
+                double nsl_values[2] = { 0, 0 };
+                double ihs_values[2] = { 0, 0 };
+                int counts[2] = { 0, 0 };
+                if (flanks.first != -1)
+                    {
+                        for (std::size_t i = 0; i < m.nsam - 1; ++i)
+                            {
+                                auto sample_i = get_ConstColView(m, i);
+                                for (std::size_t j = i + 1; j < m.nsam; ++j)
+                                    {
+                                        if (update_edge_matrix(
+                                                m, xtons, flanks, core_view,
+                                                sample_i, edges, core, i, j))
+                                            {
+                                                lindex = j * m.nsam + i;
+                                                rindex = i * m.nsam + j;
+                                                update_counts(
+                                                    nsl_values, ihs_values,
+                                                    counts, m.nsites,
+                                                    m.positions,
+                                                    static_cast<std::size_t>(
+                                                        core_view[i]
+                                                        == refstate),
+                                                    edges[lindex],
+                                                    edges[rindex]);
+                                            }
+                                    }
+                            }
+                    }
+                rv.emplace_back(get_stat(core_view, refstate, nsl_values,
+                                         ihs_values, counts));
+            }
+        return rv;
+    }
+} // namespace Sequence

--- a/src/summstats/nslx.cc
+++ b/src/summstats/nslx.cc
@@ -6,12 +6,6 @@
 namespace
 {
     inline bool
-    is_xton(const std::vector<std::int64_t>& xtons, const std::int64_t test)
-    {
-        return std::binary_search(xtons.begin(), xtons.end(), test);
-    }
-
-    inline bool
     update_edge_matrix(const Sequence::VariantMatrix& m,
                        const std::vector<std::int64_t>& xtons,
                        const std::pair<std::int64_t, std::int64_t> flanks,

--- a/src/summstats/nslx.cc
+++ b/src/summstats/nslx.cc
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <Sequence/summstats/nsl.hpp>
 #include <Sequence/VariantMatrixViews.hpp>
+#include <iostream>
 #include "nsl_common.hpp"
 
 namespace
@@ -49,13 +50,13 @@ namespace
                                 for (auto r = flanks.second;
                                      r < xtons.size() && rv == false; ++r)
                                     {
-                                        if (!(r < core))
+                                        if (!(core <= xtons[r]))
                                             {
                                                 throw std::logic_error(
                                                     "r < core");
                                             }
-                                        if (hapi[r] != hapj[r]
-                                            && !(hapi[r] < 0))
+                                        if (hapi[xtons[r]] != hapj[xtons[r]]
+                                            && !(hapi[xtons[r]] < 0))
                                             {
                                                 rv = true;
                                                 edges[rindex] = r;

--- a/src/summstats/nslx.cc
+++ b/src/summstats/nslx.cc
@@ -42,8 +42,12 @@ namespace
                             || static_cast<std::size_t>(right_edge) <= core)
                             {
                                 rv = false;
-                                for (auto r = flanks.second; r < xtons.size();
-                                     ++r)
+                                // To update right edge:
+                                // Iterate over all xtons > core
+                                // and check if haplotypes i,j
+                                // differ at those sites.
+                                for (auto r = flanks.second;
+                                     r < xtons.size() && rv == false; ++r)
                                     {
                                         if (!(r < core))
                                             {

--- a/src/summstats/nslx.cc
+++ b/src/summstats/nslx.cc
@@ -61,7 +61,8 @@ namespace
                             }
                     }
             }
-        else if (is_xton(xtons, core))
+        else if (std::binary_search(xtons.begin() + flanks.first,
+                                    xtons.begin() + flanks.second, core))
             {
                 edges[lindex] = core;
             }

--- a/src/summstats/nslx.cc
+++ b/src/summstats/nslx.cc
@@ -45,6 +45,11 @@ namespace
                                 for (auto r = flanks.second; r < xtons.size();
                                      ++r)
                                     {
+                                        if (!(r < core))
+                                            {
+                                                throw std::logic_error(
+                                                    "r < core");
+                                            }
                                         if (hapi[r] != hapj[r]
                                             && !(hapi[r] < 0))
                                             {
@@ -58,6 +63,8 @@ namespace
         else if (std::binary_search(xtons.begin() + flanks.first,
                                     xtons.begin() + flanks.second, core))
             {
+                //seqs i and j differ and core is an xton,
+                //thus core is a new left
                 edges[lindex] = core;
             }
         return rv;


### PR DESCRIPTION
1. The iHS field of the return value is now correct. Fixes #50.
2. Adds a new overload of `nsl` that uses an efficient method to calculate the stat for all sites in a `VariantMatrix`.  The new method is > 10x faster than calculating the statistic for each core on its own.
3. Fix the declaration of an overload of `operator-` for `VariantMatrix` column iterators. (
3d511e9 and 3d511e9)
4. Includes a draft implementation of `nslx` that is not ready for prime time.